### PR TITLE
HotFix: "ESLint rule prettier endofline 무시"

### DIFF
--- a/taskify-web/.eslintrc.json
+++ b/taskify-web/.eslintrc.json
@@ -3,7 +3,7 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "prettier"],
   "parserOptions": {
-    "project": "./taskify-web/tsconfig.json",
+    "project": "../taskify-web/tsconfig.json",
     "createDefaultProgram": true
   },
   "env": {
@@ -30,6 +30,12 @@
     "react/jsx-props-no-spreading": "off",
     "react/require-default-props": "off",
     "import/prefer-default-export": "off",
-    "import/extensions": ["off"]
+    "import/extensions": ["off"],
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }

--- a/taskify-web/.eslintrc.json
+++ b/taskify-web/.eslintrc.json
@@ -3,7 +3,7 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "prettier"],
   "parserOptions": {
-    "project": "../taskify-web/tsconfig.json",
+    "project": "./taskify-web/tsconfig.json",
     "createDefaultProgram": true
   },
   "env": {


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [ ] 기능
- [x] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
- Prettier는 기본적으로 파일의 끝에 LF(개행 문자)를 사용하도록 설정
- 하지만 윈도우는 CRLF를 기본으로 사용함
- 이에 따라 윈도우 개발환경에서 엔터 시(개행 문자 입력) eslint에서 오류를 보냄
- 모든 개발환경에서 개발할 수 있도록 `AUTO`로 두어 ESLint가 개행문자를 자동으로 감지 및 유지함
```
"prettier/prettier": [
  "error",
  {
    "endOfLine": "auto"
  }
]
```
## 관련 티켓 및 문서
<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #25 
- Closes #25 


### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?
