### PR TITLE
Feat36 기본 버튼 구현

### DIFF
--- a/taskify-web/src/components/commons/ui-button/Button.module.scss
+++ b/taskify-web/src/components/commons/ui-button/Button.module.scss
@@ -1,0 +1,96 @@
+@import '../../../styles/mixin';
+@import '../../../styles/variables';
+
+/* theme */
+.primary {
+  background-color: $primary;
+  color: $white_ffffff;
+}
+
+.secondary {
+  background-color: $white_ffffff;
+  color: $primary;
+  border: 1px solid $gray_d9d9d9;
+}
+
+/* style */
+/* 로그인 회원가입 용 큰 사이즈 */
+.large {
+  width: 100%;
+  padding: 1.4rem 0;
+  text-align: center;
+  border-radius: 0.8rem;
+
+  font-size: $font_size_large;
+  font-style: normal;
+  line-height: normal;
+}
+
+/* 기본 수락 거절 버튼 사이즈 */
+.medium {
+  border-radius: 0.4rem;
+  @include mobile {
+    width: 10.9rem;
+    padding: 0.7rem 0;
+    font-size: $font_size_xsmall;
+  }
+  @include tablet {
+    width: 7.2rem;
+    padding: 0.6rem 0;
+    font-size: $font_size_small;
+  }
+  @include desktop {
+    width: 8.4rem;
+    padding: 0.7rem 0;
+  }
+  font-style: normal;
+  line-height: normal;
+}
+
+/* 기본 삭제 버튼 사이즈*/
+.small {
+  border-radius: 0.4rem;
+  @include mobile {
+    width: 5.2rem;
+    padding: 0.7rem 0;
+    font-size: $font_size_xsmall;
+  }
+  @include tablet {
+    width: 8.4rem;
+    font-size: $font_size_small;
+  }
+}
+
+/* 모달 확인 닫기 버튼 사이즈 */
+.modalMedium {
+  border-radius: 0.8rem;
+  @include mobile {
+    padding: 1.2rem 0;
+    width: 13.8rem;
+    font-size: $font_size_small;
+  }
+  @include tablet {
+    padding: 1.4rem 0;
+    width: 12rem;
+    font-size: $font_size_medium;
+  }
+}
+
+/* 모달 입력 버튼 사이즈(작은거) */
+.modalSmall {
+  border-radius: 0.4rem;
+  @include mobile {
+    padding: 0.7rem 3.1rem;
+    font-size: $font_size_xsmall;
+  }
+  @include tablet {
+    padding: 0.9rem 3.1rem;
+  }
+}
+
+.btn {
+  &:disabled {
+    background-color: $surface_dim;
+    color: $white_ffffff;
+  }
+}

--- a/taskify-web/src/components/commons/ui-button/Button.tsx
+++ b/taskify-web/src/components/commons/ui-button/Button.tsx
@@ -23,7 +23,7 @@ export default function Button({
   return (
     <button
       className={cx(theme, size, 'btn')}
-      type="submit"
+      type="button"
       disabled={disabled}
       onClick={onClick}
     >

--- a/taskify-web/src/components/commons/ui-button/Button.tsx
+++ b/taskify-web/src/components/commons/ui-button/Button.tsx
@@ -1,0 +1,33 @@
+import { MouseEventHandler, ReactNode } from 'react';
+import classNames from 'classnames/bind';
+import styles from './Button.module.scss';
+
+type ButtonProps = {
+  theme?: 'primary' | 'secondary';
+  disabled?: boolean;
+  children: ReactNode;
+  size?: 'large' | 'medium' | 'small' | 'modalMedium' | 'modalSmall';
+  onClick: MouseEventHandler<HTMLButtonElement>;
+};
+
+const cx = classNames.bind(styles);
+
+// 기본적인 button 컴포넌트
+export default function Button({
+  theme = 'primary',
+  disabled = false,
+  children,
+  size = 'medium',
+  onClick,
+}: ButtonProps) {
+  return (
+    <button
+      className={cx(theme, size, 'btn')}
+      type="submit"
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
기본적인 버튼 + 모달에 사용되는 버튼 구현했습니다.

- 버튼 theme는 primary(바이올렛 배경), secondary(하얀색 배경) 두가지입니다.
- 버튼 size는 large(로그인용) medium(수락, 거절), small(삭제), modalMedium(모달에서 확인 취소), modalSmall(모달에서 입력) 이 있습니다.
- disabled는 디폴트 값으로 false이며, 사용할 때 boolean값이 나오도록 조건을 작성하거나, boolean값을 가지는 변수를 넣어주세요
- eslint로 인해 `<Button disabled={false}/>` 와 같이 직접 불린값을 때려넣는 것은 안됩니다.
- onClick이벤트는 반드시 필요한 props이며, 당장 안쓰고 레이아웃만 배치하고 싶다면 `onClick={() => {}}` 와 같이 작성해놓으세요
- 기본적으로 버튼 누를때 api 요청, 상태 전환등의 기능 수행을 하는 것으로 확인되어 기본 타입은 submit이며, e.preventDefault를 꼭 사용하세요. 안그러면 그냥 넘어가집니다.

## 관련 티켓 및 문서
<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #36 
- Closes #36 

## 스크린샷, 녹화

<img width="1440" alt="스크린샷 2024-01-27 오후 1 30 04" src="https://github.com/Team-Taskify/Taskify-Web/assets/56223156/a2bb1468-9d7c-4d65-9b10-b118f1962a85">

- 반응형도 됩니다.
<img width="569" alt="스크린샷 2024-01-27 오후 1 30 20" src="https://github.com/Team-Taskify/Taskify-Web/assets/56223156/ebbb9a05-c545-4e18-9763-7c83d79e053a">


### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?

![boss-gatsby](https://github.com/Team-Taskify/Taskify-Web/assets/56223156/005c2790-9703-46c5-ac9e-f1f3eb9142ea)

