### PR TITLE
42 대형 버튼 구현(추가버튼)

### DIFF
--- a/taskify-web/src/components/commons/ui-add-button/AddButton.module.scss
+++ b/taskify-web/src/components/commons/ui-add-button/AddButton.module.scss
@@ -1,0 +1,72 @@
+@import '../../../styles/mixin';
+@import '../../../styles/variables';
+
+.btn {
+  border: 1px solid $gray_d9d9d9;
+  background: $surface_container;
+
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.addColumn {
+  border-radius: 0.8rem;
+
+  gap: 1.2rem;
+
+  @include mobile {
+    font-size: $font_size_medium;
+
+    padding: 2rem 6rem;
+  }
+  @include tablet {
+    font-size: $font_size_large;
+    padding: 2.4rem 0;
+    width: 54.4rem;
+  }
+  @include desktop {
+    width: 35.4rem;
+  }
+}
+
+.addToDo {
+  border-radius: 0.6rem;
+
+  @include mobile {
+    padding: 0.6rem 0;
+    width: 28.4rem;
+  }
+  @include tablet {
+    padding: 0.9rem 0;
+    width: 54.4rem;
+  }
+  @include desktop {
+    width: 31.4rem;
+  }
+}
+
+.addDashBoard {
+  border-radius: 0.8rem;
+
+  gap: 1.2rem;
+
+  @include mobile {
+    font-size: $font_size_xsmall;
+
+    padding: 1.9rem 0;
+    width: 26rem;
+  }
+  @include tablet {
+    font-size: $font_size_medium;
+    padding: 2.4rem 0;
+    width: 24.7rem;
+  }
+  @include desktop {
+    width: 33.2rem;
+  }
+}

--- a/taskify-web/src/components/commons/ui-add-button/AddButton.tsx
+++ b/taskify-web/src/components/commons/ui-add-button/AddButton.tsx
@@ -1,10 +1,10 @@
-// addColumn, addDashBoard, addToDo
 import { MouseEventHandler } from 'react';
 import classNames from 'classnames/bind';
 import styles from './AddButton.module.scss';
 import { TEXT } from './constant';
 import PlusChip from '../ui-plus-chip/PlusChip';
 
+// 사용 가능한 addCase 프롭 : (컬럼추가)addColumn, (대시보드 추가)addDashBoard, (할일 추가)addToDo
 type AddButtonProps = {
   onClick: MouseEventHandler<HTMLButtonElement>;
   addCase: 'addColumn' | 'addDashBoard' | 'addToDo';

--- a/taskify-web/src/components/commons/ui-add-button/AddButton.tsx
+++ b/taskify-web/src/components/commons/ui-add-button/AddButton.tsx
@@ -1,0 +1,22 @@
+// addColumn, addDashBoard, addToDo
+import { MouseEventHandler } from 'react';
+import classNames from 'classnames/bind';
+import styles from './AddButton.module.scss';
+import { TEXT } from './constant';
+import PlusChip from '../ui-plus-chip/PlusChip';
+
+type AddButtonProps = {
+  onClick: MouseEventHandler<HTMLButtonElement>;
+  addCase: 'addColumn' | 'addDashBoard' | 'addToDo';
+};
+
+const cx = classNames.bind(styles);
+
+export default function AddButton({ onClick, addCase }: AddButtonProps) {
+  return (
+    <button className={cx('btn', addCase)} type="button" onClick={onClick}>
+      {TEXT[addCase]}
+      <PlusChip />
+    </button>
+  );
+}

--- a/taskify-web/src/components/commons/ui-add-button/constant.ts
+++ b/taskify-web/src/components/commons/ui-add-button/constant.ts
@@ -1,0 +1,5 @@
+export const TEXT = {
+  addColumn: '새로운 컬럼 추가하기',
+  addToDo: '',
+  addDashBoard: '새로운 대시보드',
+};


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
+ 칩이 있는 대형 추가버튼 컴포넌트 입니다.
props로는 addCase, onClick이 있습니다.
- addCase : 피그마 상 경우가 컬럼추가(addColumn), 할일 추가(addToDo), 대시보드 추가(addDashBoard) 세종류라 세종류입니다.
- 텍스트의 경우 커스터마이징 할 필요가 없어 constant.ts 에 상수로 넣어놨습니다. (상수로 뺄게 많으면 constant 로 사용하는데, 한가지 변수더라도 일관된 코드 가독성 고려해 이대로 가는게 좋을 것 같아 건의 해봅니다)
- onClick : 그냥 버튼동작 관련

## 관련 티켓 및 문서
<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #42 
- Closes #42 

## 스크린샷, 녹화
- 데탑
<img width="603" alt="스크린샷 2024-01-27 오후 5 17 31" src="https://github.com/Team-Taskify/Taskify-Web/assets/56223156/4f157881-8ed6-4d0c-933c-25033cc12b94">

- 태블릿
<img width="758" alt="스크린샷 2024-01-27 오후 5 17 37" src="https://github.com/Team-Taskify/Taskify-Web/assets/56223156/c9f7928f-ca35-4792-b88f-7e5e1f6b6359">

- 모바일
<img width="571" alt="스크린샷 2024-01-27 오후 5 17 43" src="https://github.com/Team-Taskify/Taskify-Web/assets/56223156/5dfdad46-313d-4036-b462-206f05a8aefb">




### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?