### PR TITLE
hotfix: "Sass 글로벌 색상 시스템 outline 변경"

### DIFF
--- a/taskify-web/src/styles/_variables.scss
+++ b/taskify-web/src/styles/_variables.scss
@@ -38,7 +38,7 @@ $surface: $gray_fafafa !default;
 $on_surface: $black_333236 !default;
 $surface_container: $white_ffffff !default;
 $surface_dim: $gray_9fa6b2 !default;
-$outline: $black_333236 !default;
+$outline: $gray_d9d9d9 !default;
 $error: $red_d6173a !default;
 
 //== Scaffolding


### PR DESCRIPTION
$black_333236 -> $gray_d9d9d9