### PR TITLE
feat:68 axios 인스턴스 구현

### DIFF
--- a/taskify-web/src/lib/api/axiosInstance.ts
+++ b/taskify-web/src/lib/api/axiosInstance.ts
@@ -1,0 +1,27 @@
+import axios, {
+  AxiosHeaders,
+  AxiosInstance,
+  InternalAxiosRequestConfig,
+} from 'axios';
+
+/**
+ * @alert 해당 인스턴스를 사용할 때 첫번째 path는 /를 사용하지 않습니다.
+ * '/dashboards/@'라고 예를 들자면 'dashboards/@' 식으로 사용
+ */
+export const axiosInstance: AxiosInstance = axios.create({
+  baseURL: 'https://sp-taskify-api.vercel.app/2-11/',
+});
+
+axiosInstance.interceptors.request.use(
+  (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
+    const accessToken = sessionStorage.getItem('accessToken');
+
+    if (accessToken) {
+      (config.headers as AxiosHeaders).set(
+        'Authorization',
+        `Bearer ${accessToken}`,
+      );
+    }
+    return config;
+  },
+);


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
axiosInstance 입니다. 요청할때 accessToken이 세션스토리지에 저장되어 있으면 자동으로 붙여서 보내줍니다.

타입 찾는데 매우매우 오래걸렸습니다

사용법은 https://www.notion.so/nakyoungs/Taskify-85b335b02a594b25a397875d63e69ced?p=3fb8c6c13af24a38bd42bc1741882217&pm=s

## 관련 티켓 및 문서
<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #68 
- Closes #68 

## 스크린샷, 녹화

그냥 코드만 보면 잘 돌아가는지 모르니까 간단하게 테스트를 해보았읍니다.
대시보드 목록 불러오기가 로그인이 필요한 간단한 get 요청이니까 이걸로 테스트 해보겠읍니다.

<img width="468" alt="스크린샷 2024-01-29 오후 4 16 10" src="https://github.com/Team-Taskify/Taskify-Web/assets/56223156/bac5f73f-2756-483f-8282-a1de8bc5306c">

세션 스토리지에 accessToken을 저장해놓은 상태로 간단하게 비동기함수를 짜봤습니다. 요걸 호출해보면

<img width="420" alt="스크린샷 2024-01-29 오후 4 16 39" src="https://github.com/Team-Taskify/Taskify-Web/assets/56223156/a8ddc2b9-e5d9-4c8c-9f62-277315b3f8a8">

accessToken을 잘 붙여서 보내놨기 때문에 데이터를 잘 가지고 옵니다.

<img width="344" alt="스크린샷 2024-01-29 오후 4 16 28" src="https://github.com/Team-Taskify/Taskify-Web/assets/56223156/416ce8de-f927-4d71-80a0-6ad120834244">

미리보기를 보면 실제 데이터도 볼 수 있네요. 아직은 대시보드 추가된게 없어서 저렇게 보이네요.

굿

### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?

![boss-gatsby](https://github.com/Team-Taskify/Taskify-Web/assets/56223156/2f655c49-12ae-4fb9-9383-7106925d33cd)
