### PR TITLE
57 서브헤더 사용자 칩 구현

### DIFF
--- a/taskify-web/src/components/commons/ui-user-badge/UserBadge.module.scss
+++ b/taskify-web/src/components/commons/ui-user-badge/UserBadge.module.scss
@@ -1,0 +1,41 @@
+@import '../../../styles/variables';
+@import '../../../styles/mixin';
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
+
+.Badge {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 3.8rem;
+  height: 3.8rem;
+  border-radius: 100%;
+  border: 0.2rem solid $surface_container;
+
+  &.orange {
+    background: #ffc85a;
+  }
+  &.pink {
+    background: #f4d7da;
+  }
+  &.sky {
+    background: #9dd7ed;
+  }
+  &.brown {
+    background: #c4b1a2;
+  }
+
+  @include mobile {
+    width: 3.4rem;
+    height: 3.4rem;
+  }
+  @include tablet {
+    width: 3.8rem;
+    height: 3.8rem;
+  }
+}
+
+.Badge-text {
+  font-family: Montserrat;
+  font-weight: 600;
+  color: $surface_container;
+}

--- a/taskify-web/src/components/commons/ui-user-badge/UserBadge.module.scss
+++ b/taskify-web/src/components/commons/ui-user-badge/UserBadge.module.scss
@@ -11,6 +11,10 @@
   border-radius: 100%;
   border: 0.2rem solid $surface_container;
 
+  &.image {
+    background: cover;
+  }
+
   &.orange {
     background: #ffc85a;
   }

--- a/taskify-web/src/components/commons/ui-user-badge/UserBadge.tsx
+++ b/taskify-web/src/components/commons/ui-user-badge/UserBadge.tsx
@@ -1,0 +1,34 @@
+import classNames from 'classnames/bind';
+import styles from './UserBadge.module.scss';
+
+const cx = classNames.bind(styles);
+
+type UserBadgeProps = {
+  color: 'orange' | 'pink' | 'brown' | 'sky';
+  text: string;
+  profileImageUrl?: string;
+};
+
+export default function UserBadge({
+  color,
+  text,
+  profileImageUrl = '',
+}: UserBadgeProps) {
+  const firstWord = text.charAt(0);
+
+  return (
+    <div>
+      {profileImageUrl ? (
+        <img
+          className={cx('Badge')}
+          src={profileImageUrl}
+          alt="프로필 이미지"
+        />
+      ) : (
+        <div className={cx('Badge', color)}>
+          <span className={cx('Badge-text')}>{firstWord}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/taskify-web/src/components/commons/ui-user-badge/UserBadge.tsx
+++ b/taskify-web/src/components/commons/ui-user-badge/UserBadge.tsx
@@ -5,39 +5,49 @@ const cx = classNames.bind(styles);
 
 /**
  * `UserBadgeProps는 사용자 칩 컴포넌트의 속성을 정의하는 타입입니다.`
- * 이 타입은 칩의 색상(color), 닉네임 첫 글자(text), 그리고 프로필 이미지(profileImageUrl)로 구성되어있습니다.
+ * 이 타입은 칩의 색상(color), 닉네임 첫 글자(text), 두 글자를 표시할지의 여부 (IsTwoWord), 그리고 프로필 이미지(profileImageUrl)로 구성되어있습니다.
  *
  * @typeof {object} UserBadgeProps
  * @property {'orange' | 'pink' | 'brown' | 'sky'} color - 칩의 4가지 색상중 1개를 props로 내려받아 표시, 부모컴포넌트에서 칩의 색상을 랜덤으로 가져옴
  * @property {string} text - 사용자 닉네임의 첫글자를 칩의 정가운데에 표시
  * @property {string} profileImageUrl - 프로필이미지가 등록된 사용자의 경우 색상칩이 아닌 프로필이미지로 표시
+ * @property {boolean} IsTwoWord - 두 글자를 가져온다면 true 값을 props로 내려 받아 표시, 기본 값은 false로 한글자만 표시
  */
 
 type UserBadgeProps = {
   color: 'orange' | 'pink' | 'brown' | 'sky';
   text: string;
   profileImageUrl?: string;
+  IsTwoWord?: boolean;
 };
 
 export default function UserBadge({
   color,
   text,
   profileImageUrl = '',
+  IsTwoWord = false,
 }: UserBadgeProps) {
   const firstWord = text.charAt(0);
+  const twoWord = text.substring(0, 2);
 
   return (
     <div>
-      {profileImageUrl ? (
+      {!profileImageUrl &&
+        (IsTwoWord ? (
+          <div className={cx('Badge', color)}>
+            <span className={cx('Badge-text')}>{twoWord}</span>
+          </div>
+        ) : (
+          <div className={cx('Badge', color)}>
+            <span className={cx('Badge-text')}>{firstWord}</span>
+          </div>
+        ))}
+      {profileImageUrl && (
         <img
-          className={cx('Badge')}
+          className={cx('Badge', 'image')}
           src={profileImageUrl}
           alt="프로필 이미지"
         />
-      ) : (
-        <div className={cx('Badge', color)}>
-          <span className={cx('Badge-text')}>{firstWord}</span>
-        </div>
       )}
     </div>
   );

--- a/taskify-web/src/components/commons/ui-user-badge/UserBadge.tsx
+++ b/taskify-web/src/components/commons/ui-user-badge/UserBadge.tsx
@@ -3,6 +3,16 @@ import styles from './UserBadge.module.scss';
 
 const cx = classNames.bind(styles);
 
+/**
+ * `UserBadgeProps는 사용자 칩 컴포넌트의 속성을 정의하는 타입입니다.`
+ * 이 타입은 칩의 색상(color), 닉네임 첫 글자(text), 그리고 프로필 이미지(profileImageUrl)로 구성되어있습니다.
+ *
+ * @typeof {object} UserBadgeProps
+ * @property {'orange' | 'pink' | 'brown' | 'sky'} color - 칩의 4가지 색상중 1개를 props로 내려받아 표시, 부모컴포넌트에서 칩의 색상을 랜덤으로 가져옴
+ * @property {string} text - 사용자 닉네임의 첫글자를 칩의 정가운데에 표시
+ * @property {string} profileImageUrl - 프로필이미지가 등록된 사용자의 경우 색상칩이 아닌 프로필이미지로 표시
+ */
+
 type UserBadgeProps = {
   color: 'orange' | 'pink' | 'brown' | 'sky';
   text: string;


### PR DESCRIPTION
## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명

props
- color : 칩의 색상
- text : 사용자 닉네임 첫 글자
- profileImageUrl : 사용자 프로필 이미지
- IsTwoWord : 두 글자 표시 여부

## 관련 티켓 및 문서

- Related Issue #57 
- Closes #57 

## 스크린샷, 녹화
![222](https://github.com/Team-Taskify/Taskify-Web/assets/148832721/39baa770-0861-4094-81ee-f0639c2a2402)

- 테스트 코드

```
import UserBadge from '@/components/commons/ui-user-badge/UserBadge';

export default function Home() {
  return (
    <div>
      <UserBadge color="orange" text="A" />
      <UserBadge color="pink" text="B" />
      <UserBadge color="sky" text="C" />
      <UserBadge color="brown" text="D" />
      <UserBadge color="sky" text="+7" IsTwoWord />
      <UserBadge color="sky" text="++" profileImageUrl="./dd.jpg" />
    </div>
  );
}
```



### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_

- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## 질문
![d](https://github.com/Team-Taskify/Taskify-Web/assets/148832721/e11c8130-82bd-4f72-ad74-898d6628a579)

- 서브헤더의 대시보드 맴버 목록은 위와 같이 칩이 겹치도록 구현되어있는데, 상위 div에 relative를 주고 userbadge 컴포넌트에 absolute를 주면 map으로 나열한 칩들이 한곳에 겹치더라고요 ㅎㅎ.. 혹시 방법이 있을까요??
- 맴버목록 제일오른쪽 칩은 왼쪽에 표시된 사용자들을 제외한 나머지 멤버들의 수를 +숫자로 표시되어있는데, userbadge 컴포넌트의 text props는 첫글자만 따오도록 하고있어서요. +(숫자)를 표시하려면 text props를 2글자로 가져와서 1글자, 2글자로 조건 처리해야될까요??