### PR TITLE
86 페이지회원가입 페이지 구현

### DIFF
--- a/taskify-web/src/components/auth/feature-signup-form/SignUpForm.module.scss
+++ b/taskify-web/src/components/auth/feature-signup-form/SignUpForm.module.scss
@@ -1,0 +1,46 @@
+@import '../../../styles/mixin';
+@import '../../../styles/variables';
+
+.form {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+
+  @include mobile {
+    margin-top: 4rem;
+    margin-bottom: 2.4rem;
+  }
+  @include tablet {
+    margin-top: 6rem;
+  }
+  @include desktop {
+    margin-top: 3.8rem;
+  }
+}
+
+.inputContainer {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.buttonContainer {
+  margin-top: 0.4rem;
+}
+
+.checkboxContainer {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.checkbox {
+  width: 2rem;
+  height: 2rem;
+
+  &:checked {
+    accent-color: $primary;
+  }
+}

--- a/taskify-web/src/components/auth/feature-signup-form/SignUpForm.tsx
+++ b/taskify-web/src/components/auth/feature-signup-form/SignUpForm.tsx
@@ -12,14 +12,17 @@ import { AuthModal } from '../ui-auth-modal/AuthModal';
 
 const cx = classNames.bind(styles);
 
+/** signup 페이지에서 쓰는 폼 컴포넌트입니다. */
 export default function SignUpForm() {
   const router = useRouter();
   const { signup, success, error } = useAuth();
+  // 모달 상태
   const [modalStatus, setModalStatus] = useState<{
     isOpen: boolean;
     messageType: 'signUpError' | 'signUpSuccess';
   }>({ isOpen: false, messageType: 'signUpError' });
   const [isChecked, setIsChecked] = useState<boolean>(false);
+  // input 유효 여부
   const [isValid, setIsValid] = useState<{
     email: boolean;
     nickname: boolean;
@@ -37,6 +40,7 @@ export default function SignUpForm() {
     mode: 'onBlur',
   });
 
+  /** 제출 이벤트 */
   const handleSubmit = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     const value = {
@@ -52,6 +56,7 @@ export default function SignUpForm() {
   };
 
   useEffect(() => {
+    /** 성공상태면 modal 성공으로 염 */
     if (success) {
       setModalStatus((prevValues) => ({
         ...prevValues,
@@ -59,6 +64,7 @@ export default function SignUpForm() {
         messageType: 'signUpSuccess',
       }));
     }
+    /** 에러 발생시 에러모달 오픈 */
     if (error?.response?.status === 409) {
       setModalStatus((prevValues) => ({
         ...prevValues,

--- a/taskify-web/src/components/auth/feature-signup-form/SignUpForm.tsx
+++ b/taskify-web/src/components/auth/feature-signup-form/SignUpForm.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import classNames from 'classnames/bind';
+import styles from './SignUpForm.module.scss';
+import { Input } from '@/components/commons/ui-input/Input';
+import PasswordInput from '../ui-password-input/PasswordInput';
+import Button from '@/components/commons/ui-button/Button';
+import { TEXT } from './constant';
+
+const cx = classNames.bind(styles);
+
+export default function SignUpForm() {
+  const [isChecked, setIsChecked] = useState<boolean>(false);
+
+  const { control } = useForm({
+    defaultValues: {
+      email: '',
+      nickname: '',
+      password: '',
+      passwordRepeat: '',
+    },
+    mode: 'onBlur',
+  });
+  return (
+    <form className={cx('form')}>
+      <label className={cx('inputContainer')}>
+        {TEXT.email.label}
+        <Controller
+          control={control}
+          name="email"
+          defaultValue=""
+          rules={{
+            required: TEXT.email.message.required,
+            pattern: {
+              value: /\S@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+              message: TEXT.email.message.pattern,
+            },
+          }}
+          render={({ field, fieldState }) => (
+            <Input
+              {...field}
+              placeholder={TEXT.email.message.required}
+              hasError={Boolean(fieldState.error)}
+              errorMessage={fieldState.error?.message}
+            />
+          )}
+        />
+      </label>
+      <label className={cx('inputContainer')}>
+        {TEXT.nickname.label}
+        <Controller
+          control={control}
+          name="nickname"
+          defaultValue=""
+          rules={{
+            required: TEXT.nickname.message.required,
+            pattern: {
+              value: /^.{1,8}$/,
+              message: TEXT.nickname.message.pattern,
+            },
+          }}
+          render={({ field, fieldState }) => (
+            <Input
+              {...field}
+              placeholder="닉네임을 입력해 주세요"
+              hasError={Boolean(fieldState.error)}
+              errorMessage={fieldState.error?.message}
+            />
+          )}
+        />
+      </label>
+      <label className={cx('inputContainer')}>
+        {TEXT.password.label}
+        <Controller
+          control={control}
+          name="password"
+          defaultValue=""
+          rules={{
+            required: TEXT.password.message.required,
+            pattern: {
+              value: /^(?=.*[a-zA-Z0-9]).{8,25}$/,
+              message: TEXT.password.message.pattern,
+            },
+          }}
+          render={({ field, fieldState }) => (
+            <PasswordInput
+              {...field}
+              placeholder="8자 이상 입력해 주세요"
+              hasError={Boolean(fieldState.error)}
+              errorMessage={fieldState.error?.message}
+            />
+          )}
+        />
+      </label>
+      <label className={cx('inputContainer')}>
+        비밀번호 확인
+        <Controller
+          control={control}
+          name="passwordRepeat"
+          defaultValue=""
+          render={({ field }) => <PasswordInput {...field} />}
+        />
+      </label>
+      <label className={cx('checkboxContainer')}>
+        <input
+          className={cx('checkbox')}
+          type="checkbox"
+          onClick={() => {
+            setIsChecked(!isChecked);
+          }}
+        />{' '}
+        {TEXT.policy}
+      </label>
+      <div className={cx('buttonContainer')}>
+        <Button disabled={!isChecked} onClick={() => {}} size="large">
+          회원가입
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/taskify-web/src/components/auth/feature-signup-form/SignUpForm.tsx
+++ b/taskify-web/src/components/auth/feature-signup-form/SignUpForm.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { MouseEvent, useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import classNames from 'classnames/bind';
 import styles from './SignUpForm.module.scss';
@@ -6,10 +7,18 @@ import { Input } from '@/components/commons/ui-input/Input';
 import PasswordInput from '../ui-password-input/PasswordInput';
 import Button from '@/components/commons/ui-button/Button';
 import { TEXT } from './constant';
+import { useAuth } from '@/contexts/AuthProvider';
+import { AuthModal } from '../ui-auth-modal/AuthModal';
 
 const cx = classNames.bind(styles);
 
 export default function SignUpForm() {
+  const router = useRouter();
+  const { signup, success, error } = useAuth();
+  const [modalStatus, setModalStatus] = useState<{
+    isOpen: boolean;
+    messageType: 'signUpError' | 'signUpSuccess';
+  }>({ isOpen: false, messageType: 'signUpError' });
   const [isChecked, setIsChecked] = useState<boolean>(false);
   const [isValid, setIsValid] = useState<{
     email: boolean;
@@ -28,161 +37,206 @@ export default function SignUpForm() {
     mode: 'onBlur',
   });
 
+  const handleSubmit = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    const value = {
+      email: watch('email'),
+      nickname: watch('nickname'),
+      password: watch('password'),
+    };
+    signup({
+      email: value.email,
+      nickname: value.nickname,
+      password: value.password,
+    });
+  };
+
+  useEffect(() => {
+    if (success) {
+      setModalStatus((prevValues) => ({
+        ...prevValues,
+        isOpen: true,
+        messageType: 'signUpSuccess',
+      }));
+    }
+    if (error?.response?.status === 409) {
+      setModalStatus((prevValues) => ({
+        ...prevValues,
+        isOpen: true,
+        messageType: 'signUpError',
+      }));
+    }
+  }, [success, error]);
+
   return (
-    <form className={cx('form')}>
-      <label className={cx('inputContainer')}>
-        {TEXT.email.label}
-        <Controller
-          control={control}
-          name="email"
-          defaultValue=""
-          rules={{
-            required: TEXT.email.message.required,
-            pattern: {
-              value: /\S@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-              message: TEXT.email.message.pattern,
-            },
-          }}
-          render={({ field, fieldState }) => (
-            <Input
-              {...field}
-              onBlur={() => {
-                trigger('email').then(() => {
-                  if (!getFieldState('email').invalid) {
-                    setIsValid((prev) => ({ ...prev, email: true }));
-                  } else {
-                    setIsValid((prev) => ({ ...prev, email: false }));
-                  }
-                });
-              }}
-              placeholder={TEXT.email.message.required}
-              hasError={Boolean(fieldState.error)}
-              errorMessage={fieldState.error?.message}
-            />
-          )}
-        />
-      </label>
-      <label className={cx('inputContainer')}>
-        {TEXT.nickname.label}
-        <Controller
-          control={control}
-          name="nickname"
-          defaultValue=""
-          rules={{
-            required: TEXT.nickname.message.required,
-            pattern: {
-              value: /^.{1,10}$/,
-              message: TEXT.nickname.message.pattern,
-            },
-          }}
-          render={({ field, fieldState }) => (
-            <Input
-              {...field}
-              onBlur={() => {
-                trigger('nickname').then(() => {
-                  if (!getFieldState('nickname').invalid) {
-                    setIsValid({ ...isValid, nickname: true });
-                  } else {
-                    setIsValid({ ...isValid, nickname: false });
-                  }
-                });
-              }}
-              placeholder={TEXT.nickname.message.required}
-              hasError={Boolean(fieldState.error)}
-              errorMessage={fieldState.error?.message}
-            />
-          )}
-        />
-      </label>
-      <label className={cx('inputContainer')}>
-        {TEXT.password.label}
-        <Controller
-          control={control}
-          name="password"
-          defaultValue=""
-          rules={{
-            required: TEXT.password.message.required,
-            pattern: {
-              value: /^(?=.*[a-zA-Z0-9]).{8,25}$/,
-              message: TEXT.password.message.pattern,
-            },
-          }}
-          render={({ field, fieldState }) => (
-            <PasswordInput
-              {...field}
-              onBlur={() => {
-                trigger('password').then(() => {
-                  if (!getFieldState('password').invalid) {
-                    setIsValid({ ...isValid, password: true });
-                  } else {
-                    setIsValid({ ...isValid, password: false });
-                  }
-                });
-              }}
-              placeholder={TEXT.password.message.pattern}
-              hasError={Boolean(fieldState.error)}
-              errorMessage={fieldState.error?.message}
-            />
-          )}
-        />
-      </label>
-      <label className={cx('inputContainer')}>
-        {TEXT.passwordRepeat.label}
-        <Controller
-          control={control}
-          name="passwordRepeat"
-          defaultValue=""
-          rules={{
-            required: TEXT.passwordRepeat.message.required,
-            validate: (value) =>
-              value === watch('password')
-                ? true
-                : TEXT.passwordRepeat.message.pattern,
-          }}
-          render={({ field, fieldState }) => (
-            <PasswordInput
-              {...field}
-              onBlur={() => {
-                trigger('passwordRepeat').then(() => {
-                  if (!getFieldState('passwordRepeat').invalid) {
-                    setIsValid({ ...isValid, passwordRepeat: true });
-                  } else {
-                    setIsValid({ ...isValid, passwordRepeat: false });
-                  }
-                });
-              }}
-              placeholder={TEXT.passwordRepeat.message.required}
-              hasError={Boolean(fieldState.error)}
-              errorMessage={fieldState.error?.message}
-            />
-          )}
-        />
-      </label>
-      <label className={cx('checkboxContainer')}>
-        <input
-          className={cx('checkbox')}
-          type="checkbox"
-          onClick={() => {
-            setIsChecked(!isChecked);
-          }}
-        />{' '}
-        {TEXT.policy}
-      </label>
-      <div className={cx('buttonContainer')}>
-        <Button
-          disabled={
-            !isChecked ||
-            !isValid.email ||
-            !isValid.nickname ||
-            !isValid.password ||
-            !isValid.passwordRepeat
+    <>
+      <AuthModal
+        isOpen={modalStatus.isOpen}
+        messageType={modalStatus.messageType}
+        onClick={() => {
+          if (modalStatus.messageType === 'signUpError') {
+            setModalStatus((prevValues) => ({ ...prevValues, isOpen: false }));
+          } else {
+            setModalStatus((prevValues) => ({ ...prevValues, isOpen: false }));
+            router.push('/signin');
           }
-          onClick={() => {}}
-          size="large"
-        >
-          {TEXT.button}
-        </Button>
-      </div>
-    </form>
+        }}
+      />
+      <form className={cx('form')}>
+        <label className={cx('inputContainer')}>
+          {TEXT.email.label}
+          <Controller
+            control={control}
+            name="email"
+            defaultValue=""
+            rules={{
+              required: TEXT.email.message.required,
+              pattern: {
+                value: /\S@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                message: TEXT.email.message.pattern,
+              },
+            }}
+            render={({ field, fieldState }) => (
+              <Input
+                {...field}
+                onBlur={() => {
+                  trigger('email').then(() => {
+                    if (!getFieldState('email').invalid) {
+                      setIsValid((prev) => ({ ...prev, email: true }));
+                    } else {
+                      setIsValid((prev) => ({ ...prev, email: false }));
+                    }
+                  });
+                }}
+                placeholder={TEXT.email.message.required}
+                hasError={Boolean(fieldState.error)}
+                errorMessage={fieldState.error?.message}
+              />
+            )}
+          />
+        </label>
+        <label className={cx('inputContainer')}>
+          {TEXT.nickname.label}
+          <Controller
+            control={control}
+            name="nickname"
+            defaultValue=""
+            rules={{
+              required: TEXT.nickname.message.required,
+              pattern: {
+                value: /^.{1,10}$/,
+                message: TEXT.nickname.message.pattern,
+              },
+            }}
+            render={({ field, fieldState }) => (
+              <Input
+                {...field}
+                onBlur={() => {
+                  trigger('nickname').then(() => {
+                    if (!getFieldState('nickname').invalid) {
+                      setIsValid({ ...isValid, nickname: true });
+                    } else {
+                      setIsValid({ ...isValid, nickname: false });
+                    }
+                  });
+                }}
+                placeholder={TEXT.nickname.message.required}
+                hasError={Boolean(fieldState.error)}
+                errorMessage={fieldState.error?.message}
+              />
+            )}
+          />
+        </label>
+        <label className={cx('inputContainer')}>
+          {TEXT.password.label}
+          <Controller
+            control={control}
+            name="password"
+            defaultValue=""
+            rules={{
+              required: TEXT.password.message.required,
+              pattern: {
+                value: /^(?=.*[a-zA-Z0-9]).{8,25}$/,
+                message: TEXT.password.message.pattern,
+              },
+            }}
+            render={({ field, fieldState }) => (
+              <PasswordInput
+                {...field}
+                onBlur={() => {
+                  trigger('password').then(() => {
+                    if (!getFieldState('password').invalid) {
+                      setIsValid({ ...isValid, password: true });
+                    } else {
+                      setIsValid({ ...isValid, password: false });
+                    }
+                  });
+                }}
+                placeholder={TEXT.password.message.pattern}
+                hasError={Boolean(fieldState.error)}
+                errorMessage={fieldState.error?.message}
+              />
+            )}
+          />
+        </label>
+        <label className={cx('inputContainer')}>
+          {TEXT.passwordRepeat.label}
+          <Controller
+            control={control}
+            name="passwordRepeat"
+            defaultValue=""
+            rules={{
+              required: TEXT.passwordRepeat.message.required,
+              validate: (value) =>
+                value === watch('password')
+                  ? true
+                  : TEXT.passwordRepeat.message.pattern,
+            }}
+            render={({ field, fieldState }) => (
+              <PasswordInput
+                {...field}
+                onBlur={() => {
+                  trigger('passwordRepeat').then(() => {
+                    if (!getFieldState('passwordRepeat').invalid) {
+                      setIsValid({ ...isValid, passwordRepeat: true });
+                    } else {
+                      setIsValid({ ...isValid, passwordRepeat: false });
+                    }
+                  });
+                }}
+                placeholder={TEXT.passwordRepeat.message.required}
+                hasError={Boolean(fieldState.error)}
+                errorMessage={fieldState.error?.message}
+              />
+            )}
+          />
+        </label>
+        <label className={cx('checkboxContainer')}>
+          <input
+            className={cx('checkbox')}
+            type="checkbox"
+            onClick={() => {
+              setIsChecked(!isChecked);
+            }}
+          />{' '}
+          {TEXT.policy}
+        </label>
+        <div className={cx('buttonContainer')}>
+          <Button
+            disabled={
+              !isChecked ||
+              !isValid.email ||
+              !isValid.nickname ||
+              !isValid.password ||
+              !isValid.passwordRepeat
+            }
+            onClick={handleSubmit}
+            size="large"
+          >
+            {TEXT.button}
+          </Button>
+        </div>
+      </form>
+    </>
   );
 }

--- a/taskify-web/src/components/auth/feature-signup-form/SignUpForm.tsx
+++ b/taskify-web/src/components/auth/feature-signup-form/SignUpForm.tsx
@@ -11,8 +11,14 @@ const cx = classNames.bind(styles);
 
 export default function SignUpForm() {
   const [isChecked, setIsChecked] = useState<boolean>(false);
+  const [isValid, setIsValid] = useState<{
+    email: boolean;
+    nickname: boolean;
+    password: boolean;
+    passwordRepeat: boolean;
+  }>({ email: false, password: false, passwordRepeat: false, nickname: false });
 
-  const { control } = useForm({
+  const { control, watch, trigger, getFieldState } = useForm({
     defaultValues: {
       email: '',
       nickname: '',
@@ -21,6 +27,7 @@ export default function SignUpForm() {
     },
     mode: 'onBlur',
   });
+
   return (
     <form className={cx('form')}>
       <label className={cx('inputContainer')}>
@@ -39,6 +46,15 @@ export default function SignUpForm() {
           render={({ field, fieldState }) => (
             <Input
               {...field}
+              onBlur={() => {
+                trigger('email').then(() => {
+                  if (!getFieldState('email').invalid) {
+                    setIsValid((prev) => ({ ...prev, email: true }));
+                  } else {
+                    setIsValid((prev) => ({ ...prev, email: false }));
+                  }
+                });
+              }}
               placeholder={TEXT.email.message.required}
               hasError={Boolean(fieldState.error)}
               errorMessage={fieldState.error?.message}
@@ -55,13 +71,22 @@ export default function SignUpForm() {
           rules={{
             required: TEXT.nickname.message.required,
             pattern: {
-              value: /^.{1,8}$/,
+              value: /^.{1,10}$/,
               message: TEXT.nickname.message.pattern,
             },
           }}
           render={({ field, fieldState }) => (
             <Input
               {...field}
+              onBlur={() => {
+                trigger('nickname').then(() => {
+                  if (!getFieldState('nickname').invalid) {
+                    setIsValid({ ...isValid, nickname: true });
+                  } else {
+                    setIsValid({ ...isValid, nickname: false });
+                  }
+                });
+              }}
               placeholder="닉네임을 입력해 주세요"
               hasError={Boolean(fieldState.error)}
               errorMessage={fieldState.error?.message}
@@ -85,6 +110,15 @@ export default function SignUpForm() {
           render={({ field, fieldState }) => (
             <PasswordInput
               {...field}
+              onBlur={() => {
+                trigger('password').then(() => {
+                  if (!getFieldState('password').invalid) {
+                    setIsValid({ ...isValid, password: true });
+                  } else {
+                    setIsValid({ ...isValid, password: false });
+                  }
+                });
+              }}
               placeholder="8자 이상 입력해 주세요"
               hasError={Boolean(fieldState.error)}
               errorMessage={fieldState.error?.message}
@@ -93,12 +127,35 @@ export default function SignUpForm() {
         />
       </label>
       <label className={cx('inputContainer')}>
-        비밀번호 확인
+        {TEXT.passwordRepeat.label}
         <Controller
           control={control}
           name="passwordRepeat"
           defaultValue=""
-          render={({ field }) => <PasswordInput {...field} />}
+          rules={{
+            required: TEXT.passwordRepeat.message.required,
+            validate: (value) =>
+              value === watch('password')
+                ? true
+                : TEXT.passwordRepeat.message.pattern,
+          }}
+          render={({ field, fieldState }) => (
+            <PasswordInput
+              {...field}
+              onBlur={() => {
+                trigger('passwordRepeat').then(() => {
+                  if (!getFieldState('passwordRepeat').invalid) {
+                    setIsValid({ ...isValid, passwordRepeat: true });
+                  } else {
+                    setIsValid({ ...isValid, passwordRepeat: false });
+                  }
+                });
+              }}
+              placeholder={TEXT.passwordRepeat.message.required}
+              hasError={Boolean(fieldState.error)}
+              errorMessage={fieldState.error?.message}
+            />
+          )}
         />
       </label>
       <label className={cx('checkboxContainer')}>
@@ -112,7 +169,17 @@ export default function SignUpForm() {
         {TEXT.policy}
       </label>
       <div className={cx('buttonContainer')}>
-        <Button disabled={!isChecked} onClick={() => {}} size="large">
+        <Button
+          disabled={
+            !isChecked ||
+            !isValid.email ||
+            !isValid.nickname ||
+            !isValid.password ||
+            !isValid.passwordRepeat
+          }
+          onClick={() => {}}
+          size="large"
+        >
           회원가입
         </Button>
       </div>

--- a/taskify-web/src/components/auth/feature-signup-form/SignUpForm.tsx
+++ b/taskify-web/src/components/auth/feature-signup-form/SignUpForm.tsx
@@ -87,7 +87,7 @@ export default function SignUpForm() {
                   }
                 });
               }}
-              placeholder="닉네임을 입력해 주세요"
+              placeholder={TEXT.nickname.message.required}
               hasError={Boolean(fieldState.error)}
               errorMessage={fieldState.error?.message}
             />
@@ -119,7 +119,7 @@ export default function SignUpForm() {
                   }
                 });
               }}
-              placeholder="8자 이상 입력해 주세요"
+              placeholder={TEXT.password.message.pattern}
               hasError={Boolean(fieldState.error)}
               errorMessage={fieldState.error?.message}
             />
@@ -180,7 +180,7 @@ export default function SignUpForm() {
           onClick={() => {}}
           size="large"
         >
-          회원가입
+          {TEXT.button}
         </Button>
       </div>
     </form>

--- a/taskify-web/src/components/auth/feature-signup-form/constant.ts
+++ b/taskify-web/src/components/auth/feature-signup-form/constant.ts
@@ -1,0 +1,25 @@
+export const TEXT = {
+  email: {
+    label: '이메일',
+    message: {
+      required: '이메일을 입력해 주세요',
+      pattern: '올바른 이메일 주소가 아닙니다.',
+    },
+  },
+  nickname: {
+    label: '닉네임',
+    message: {
+      required: '닉네임을 입력해 주세요',
+      pattern: '8자 이상 입력해주세요.',
+    },
+  },
+  password: {
+    label: '비밀번호',
+    message: {
+      required: '비밀번호를 입력해 주세요',
+      pattern: '8자 이상 작성해 주세요.',
+    },
+  },
+  button: '회원가입',
+  policy: '이용약관에 동의합니다.',
+};

--- a/taskify-web/src/components/auth/feature-signup-form/constant.ts
+++ b/taskify-web/src/components/auth/feature-signup-form/constant.ts
@@ -10,7 +10,7 @@ export const TEXT = {
     label: '닉네임',
     message: {
       required: '닉네임을 입력해 주세요',
-      pattern: '8자 이상 입력해주세요.',
+      pattern: '열 자 이하로 작성해주세요.',
     },
   },
   password: {
@@ -18,6 +18,13 @@ export const TEXT = {
     message: {
       required: '비밀번호를 입력해 주세요',
       pattern: '8자 이상 작성해 주세요.',
+    },
+  },
+  passwordRepeat: {
+    label: '비밀번호 확인',
+    message: {
+      required: '비밀번호를 한번 더 입력해 주세요',
+      pattern: '비밀번호가 일치하지 않습니다.',
     },
   },
   button: '회원가입',

--- a/taskify-web/src/components/auth/ui-auth-footer/AuthFooter.tsx
+++ b/taskify-web/src/components/auth/ui-auth-footer/AuthFooter.tsx
@@ -14,7 +14,7 @@ const cx = classNames.bind(styles);
  * @props isSignIn : boolean값이며, 분기에 따라 텍스트가 달라집니다.
  * @default isSignIn=true
  */
-export function AuthFooter({ isSignIn = true }: AuthFooterProps) {
+export function AuthFooter({ isSignIn = false }: AuthFooterProps) {
   const textCase = isSignIn ? 'signIn' : 'signUp';
   return (
     <h2 className={cx('suggestion')}>

--- a/taskify-web/src/components/auth/ui-auth-header/AuthHeader.tsx
+++ b/taskify-web/src/components/auth/ui-auth-header/AuthHeader.tsx
@@ -17,7 +17,7 @@ const cx = classNames.bind(styles);
  * @alert 로고랑 바로 아래 텍스트가 있는 auth페이지의 헤더입니다.
  * @props isSignIn 로그인창에서 사용할 때는 true, 회원가입 창일때는 false를 넣으면 됩니다.
  */
-export function AuthHeader({ isSignIn = true }: AuthHeaderProps) {
+export function AuthHeader({ isSignIn = false }: AuthHeaderProps) {
   return (
     <header className={cx('header')}>
       <div className={cx('imageContainer')}>

--- a/taskify-web/src/contexts/AuthProvider.tsx
+++ b/taskify-web/src/contexts/AuthProvider.tsx
@@ -92,6 +92,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     router.push('/mydashboard');
   };
 
+  /** 회원가입 시도하고, 성공시 success true로 반환 */
   const signup = async ({ email, nickname, password }: SignUpForm) => {
     try {
       setAxiosError(null);

--- a/taskify-web/src/pages/signin.tsx
+++ b/taskify-web/src/pages/signin.tsx
@@ -19,9 +19,9 @@ export default function SignIn() {
   return (
     <main>
       <AuthLayout
-        authHeader={<AuthHeader />}
+        authHeader={<AuthHeader isSignIn />}
         authForm={<SignInForm />}
-        authFooter={<AuthFooter />}
+        authFooter={<AuthFooter isSignIn />}
       />
     </main>
   );

--- a/taskify-web/src/pages/signup.tsx
+++ b/taskify-web/src/pages/signup.tsx
@@ -1,9 +1,21 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import SignUpForm from '@/components/auth/feature-signup-form/SignUpForm';
 import { AuthFooter } from '@/components/auth/ui-auth-footer/AuthFooter';
 import { AuthHeader } from '@/components/auth/ui-auth-header/AuthHeader';
 import { AuthLayout } from '@/components/page-layout/auth-layout/AuthLayout';
+import { useAuth } from '@/contexts/AuthProvider';
 
 export default function SignUp() {
+  const { user } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user) {
+      router.replace('/mydashboard');
+    }
+  }, [user, router]);
+
   return (
     <main>
       <AuthLayout

--- a/taskify-web/src/pages/signup.tsx
+++ b/taskify-web/src/pages/signup.tsx
@@ -1,3 +1,4 @@
+import SignUpForm from '@/components/auth/feature-signup-form/SignUpForm';
 import { AuthFooter } from '@/components/auth/ui-auth-footer/AuthFooter';
 import { AuthHeader } from '@/components/auth/ui-auth-header/AuthHeader';
 import { AuthLayout } from '@/components/page-layout/auth-layout/AuthLayout';
@@ -7,7 +8,7 @@ export default function SignUp() {
     <main>
       <AuthLayout
         authHeader={<AuthHeader />}
-        authForm={<div>하이</div>}
+        authForm={<SignUpForm />}
         authFooter={<AuthFooter />}
       />
     </main>

--- a/taskify-web/src/pages/signup.tsx
+++ b/taskify-web/src/pages/signup.tsx
@@ -1,3 +1,15 @@
+import { AuthFooter } from '@/components/auth/ui-auth-footer/AuthFooter';
+import { AuthHeader } from '@/components/auth/ui-auth-header/AuthHeader';
+import { AuthLayout } from '@/components/page-layout/auth-layout/AuthLayout';
+
 export default function SignUp() {
-  return <div>회원가입 페이지입니다.</div>;
+  return (
+    <main>
+      <AuthLayout
+        authHeader={<AuthHeader />}
+        authForm={<div>하이</div>}
+        authFooter={<AuthFooter />}
+      />
+    </main>
+  );
 }

--- a/taskify-web/src/types/auth.ts
+++ b/taskify-web/src/types/auth.ts
@@ -4,10 +4,9 @@ export interface SignInForm {
   password: string;
 }
 
-export interface SignUpForm {
-  email: string;
+/** @type 회원가입 할 때 사용하는 폼 타입 선언 */
+export interface SignUpForm extends SignInForm {
   nickname: string;
-  password: string;
 }
 
 export interface UserData {

--- a/taskify-web/src/types/auth.ts
+++ b/taskify-web/src/types/auth.ts
@@ -4,6 +4,12 @@ export interface SignInForm {
   password: string;
 }
 
+export interface SignUpForm {
+  email: string;
+  nickname: string;
+  password: string;
+}
+
 export interface UserData {
   id: number;
   email: string;


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
회원가입 페이지입니다.
로그인이랑 비슷한데, 영상으로 확인하면 편할듯 합니다.

- 로그인을 시도할 때, 체크박스와 input 모든값의 유효성을 검증합니다. 어느 하나라도 만족하지 않으면 회원가입 버튼은 비활성화.
- api 요청시 에러 케이스는 사실상 중복 이메일 오류밖에 없기 때문에 에러 발생시 모달이 뜹니다.
- 성공시에는 Provider에 새로 추가한 success 불린값이 참이 되고, 참인 경우 성공 모달이 뜨며 모달에서 확인 클릭시 signin으로 넘어감
- 마찬가지로 로그인 상태일 때 mydashboard로 이동시킴.

## 관련 티켓 및 문서
<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #86 
- Closes #86 

## 스크린샷, 녹화

https://www.notion.so/nakyoungs/Taskify-85b335b02a594b25a397875d63e69ced?p=b5a98fc20b274c66a87f7e5e554174ce&pm=s


### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [x] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?