### PR TITLE
Feat94 유저 뱃지 컴포넌트 사이즈 변경 기능 구현

### DIFF
--- a/taskify-web/src/components/commons/ui-user-badge/UserBadge.module.scss
+++ b/taskify-web/src/components/commons/ui-user-badge/UserBadge.module.scss
@@ -6,8 +6,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 3.8rem;
-  height: 3.8rem;
   border-radius: 100%;
   border: 0.2rem solid $surface_container;
 
@@ -28,13 +26,82 @@
     background: #c4b1a2;
   }
 
-  @include mobile {
-    width: 3.4rem;
-    height: 3.4rem;
+  &.header {
+    @include mobile {
+      width: 3.4rem;
+      height: 3.4rem;
+      font-size: $font_size_small;
+    }
+    @include tablet {
+      width: 3.8rem;
+      height: 3.8rem;
+      font-size: $font_size_medium;
+    }
+    @include desktop {
+      width: 3.8rem;
+      height: 3.8rem;
+      font-size: $font_size_medium;
+    }
   }
-  @include tablet {
-    width: 3.8rem;
-    height: 3.8rem;
+
+  &.card {
+    @include mobile {
+      width: 2.6rem;
+      height: 2.6rem;
+      font-size: $font_size_xsmall;
+    }
+    @include tablet {
+      width: 3.4rem;
+      height: 3.4rem;
+      font-size: $font_size_medium;
+    }
+    @include desktop {
+      width: 3.4rem;
+      height: 3.4rem;
+      font-size: $font_size_medium;
+    }
+  }
+
+  &.column {
+    @include mobile {
+      width: 2.2rem;
+      height: 2.2rem;
+      font-size: $font_size_base;
+    }
+    @include tablet {
+      width: 2.4rem;
+      height: 2.4rem;
+      font-size: $font_size_xsmall;
+    }
+    @include desktop {
+      width: 2.4rem;
+      height: 2.4rem;
+      font-size: $font_size_xsmall;
+    }
+  }
+
+  &.dropdown {
+    width: 2.6rem;
+    height: 2.6rem;
+    font-size: $font_size_xsmall;
+  }
+
+  &.member {
+    @include mobile {
+      width: 3.4rem;
+      height: 3.4rem;
+      font-size: $font_size_small;
+    }
+    @include tablet {
+      width: 3.8rem;
+      height: 3.8rem;
+      font-size: $font_size_medium;
+    }
+    @include desktop {
+      width: 3.8rem;
+      height: 3.8rem;
+      font-size: $font_size_medium;
+    }
   }
 }
 

--- a/taskify-web/src/components/commons/ui-user-badge/UserBadge.tsx
+++ b/taskify-web/src/components/commons/ui-user-badge/UserBadge.tsx
@@ -5,13 +5,14 @@ const cx = classNames.bind(styles);
 
 /**
  * `UserBadgeProps는 사용자 칩 컴포넌트의 속성을 정의하는 타입입니다.`
- * 이 타입은 칩의 색상(color), 닉네임 첫 글자(text), 두 글자를 표시할지의 여부 (IsTwoWord), 그리고 프로필 이미지(profileImageUrl)로 구성되어있습니다.
+ * 이 타입은 칩의 색상(color), 닉네임 첫 글자(text), 두 글자를 표시할지의 여부 (IsTwoWord), 프로필 이미지(profileImageUrl), 컴포넌트 위치 별 크기 지정(location)로 구성되어있습니다.
  *
  * @typeof {object} UserBadgeProps
  * @property {'orange' | 'pink' | 'brown' | 'sky'} color - 칩의 4가지 색상중 1개를 props로 내려받아 표시, 부모컴포넌트에서 칩의 색상을 랜덤으로 가져옴
  * @property {string} text - 사용자 닉네임의 첫글자를 칩의 정가운데에 표시
  * @property {string} profileImageUrl - 프로필이미지가 등록된 사용자의 경우 색상칩이 아닌 프로필이미지로 표시
  * @property {boolean} IsTwoWord - 두 글자를 가져온다면 true 값을 props로 내려 받아 표시, 기본 값은 false로 한글자만 표시
+ * @property {'header' | 'card' | 'column' | 'dropdown' | 'member'} location - 각 컴포넌트에 맞게 뱃지크기를 변경합니다.
  */
 
 type UserBadgeProps = {
@@ -19,6 +20,7 @@ type UserBadgeProps = {
   text: string;
   profileImageUrl?: string;
   IsTwoWord?: boolean;
+  location: 'header' | 'card' | 'column' | 'dropdown' | 'member';
 };
 
 export default function UserBadge({
@@ -26,6 +28,7 @@ export default function UserBadge({
   text,
   profileImageUrl = '',
   IsTwoWord = false,
+  location,
 }: UserBadgeProps) {
   const firstWord = text.charAt(0);
   const twoWord = text.substring(0, 2);
@@ -38,13 +41,13 @@ export default function UserBadge({
             <span className={cx('Badge-text')}>{twoWord}</span>
           </div>
         ) : (
-          <div className={cx('Badge', color)}>
+          <div className={cx('Badge', color, location)}>
             <span className={cx('Badge-text')}>{firstWord}</span>
           </div>
         ))}
       {profileImageUrl && (
         <img
-          className={cx('Badge', 'image')}
+          className={cx('Badge', 'image', location)}
           src={profileImageUrl}
           alt="프로필 이미지"
         />


### PR DESCRIPTION
## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
추가 기능
- location props 추가 : 각 컴포넌트 별 유저 뱃지 크기 지정

컴포넌트 별 width, height사이즈 ( 데스크탑/태블릿/모바일  )
- 서브헤더 : (38px,38px,34px)
- 카드 : (34px,34px,26px)
- 컬럼 : (24px,24px,22px)
- 드롭다운 : (26px 동일)
- 멤버 : (38px,38px,34px)

컴포넌트 별 font 사이즈 ( 데스크탑/태블릿/모바일  )
- 서브헤더 : (16px,16px,14px)
- 카드 : (16px,16px,12px)
- 컬럼 : (12px,12px,10px)
- 드롭다운 : (12px 동일)
- 멤버 :  (16px,16px,14px)

- 서브 헤더 ( 프로필 )
![서브헤더](https://github.com/Team-Taskify/Taskify-Web/assets/148832721/b667d988-5b61-419d-81c4-d56f75670ac6)

- 카드 ( 카드 / 댓글 작성자 )
![카드](https://github.com/Team-Taskify/Taskify-Web/assets/148832721/b736e923-1786-4003-886b-89ced98926b6)

- 컬럼 ( 컬럼에서 표시되는 카드 작성자 )
![컬럼](https://github.com/Team-Taskify/Taskify-Web/assets/148832721/8726b2ad-0d2b-464c-a1ce-4aa5d7756764)

- 드롭다운 ( 담당자 ) 
![드롭다운](https://github.com/Team-Taskify/Taskify-Web/assets/148832721/99f3a6e1-ff33-415e-8a53-c6a6f919a99f)

- 멤버 ( 대시보드 구성원 )
![멤버](https://github.com/Team-Taskify/Taskify-Web/assets/148832721/1f437365-70ad-4a80-9cc3-fab239f89eb7)


## 관련 티켓 및 문서

- Related Issue #94 
- Closes #94 
- 
## 스크린샷, 녹화

- 태블릿 => 모바일 반응형CSS ( 데스크탑은 태블릿과 동일 )
![유저뱃지 크기변경](https://github.com/Team-Taskify/Taskify-Web/assets/148832721/1789f7bd-115a-429a-ae57-7a13790e9a36)


### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?