### PR TITLE
feat:100 이미지 파일 인풋 컴포넌트 구현

### DIFF
--- a/taskify-web/next.config.mjs
+++ b/taskify-web/next.config.mjs
@@ -11,6 +11,16 @@ const nextConfig = {
     // 수정된 설정을 리턴해야만 적용됩니다.
     return config;
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
+        port: '',
+        pathname: '/taskify/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/taskify-web/src/components/commons/ui-image-input/ImageInput.module.scss
+++ b/taskify-web/src/components/commons/ui-image-input/ImageInput.module.scss
@@ -8,6 +8,9 @@
   justify-content: center;
   align-items: center;
 }
+.image {
+  object-fit: cover;
+}
 .mypage {
   @include mobile {
     width: 10rem;

--- a/taskify-web/src/components/commons/ui-image-input/ImageInput.module.scss
+++ b/taskify-web/src/components/commons/ui-image-input/ImageInput.module.scss
@@ -1,0 +1,46 @@
+@import '../../../styles/mixin';
+@import '../../../styles/variables';
+.container {
+  position: relative;
+  border-radius: 0.6rem;
+  background: #f5f5f5;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.mypage {
+  @include mobile {
+    width: 10rem;
+    height: 10rem;
+  }
+  @include tablet {
+    width: 18.2rem;
+    height: 18.2rem;
+  }
+}
+
+.modal {
+  @include mobile {
+    width: 5.8rem;
+    height: 5.8rem;
+  }
+  @include tablet {
+    width: 7.6rem;
+    height: 7.6rem;
+  }
+}
+
+.input {
+  display: none;
+}
+
+.icon {
+  @include mobile {
+    width: 2rem;
+    height: 2rem;
+  }
+  @include tablet {
+    width: 3rem;
+    height: 3rem;
+  }
+}

--- a/taskify-web/src/components/commons/ui-image-input/ImageInput.tsx
+++ b/taskify-web/src/components/commons/ui-image-input/ImageInput.tsx
@@ -61,7 +61,12 @@ export default function ImageInput({
     <label className={cx('container', location)}>
       <div className={cx('container', location)}>
         {imageData.preview ? (
-          <Image src={imageData.preview} alt="미리보기" fill />
+          <Image
+            className={cx('image')}
+            src={imageData.preview}
+            alt="미리보기"
+            fill
+          />
         ) : (
           <PlusIcon className={cx('icon')} />
         )}

--- a/taskify-web/src/components/commons/ui-image-input/ImageInput.tsx
+++ b/taskify-web/src/components/commons/ui-image-input/ImageInput.tsx
@@ -72,6 +72,7 @@ export default function ImageInput({
         type="file"
         name="file"
         className={cx('input')}
+        accept="image/*"
       />
     </label>
   );

--- a/taskify-web/src/components/commons/ui-image-input/ImageInput.tsx
+++ b/taskify-web/src/components/commons/ui-image-input/ImageInput.tsx
@@ -60,7 +60,7 @@ export default function ImageInput({
   return (
     <label className={cx('container', location)}>
       <div className={cx('container', location)}>
-        {imageData.data ? (
+        {imageData.preview ? (
           <Image src={imageData.preview} alt="미리보기" fill />
         ) : (
           <PlusIcon className={cx('icon')} />

--- a/taskify-web/src/components/commons/ui-image-input/ImageInput.tsx
+++ b/taskify-web/src/components/commons/ui-image-input/ImageInput.tsx
@@ -1,0 +1,78 @@
+import Image from 'next/image';
+import {
+  Dispatch,
+  MutableRefObject,
+  SetStateAction,
+  SyntheticEvent,
+  useEffect,
+} from 'react';
+import classNames from 'classnames/bind';
+import styles from './ImageInput.module.scss';
+import PlusIcon from '../ui-plus-chip/plus.svg';
+
+const cx = classNames.bind(styles);
+
+type ImageInputProps = {
+  inputRef: MutableRefObject<HTMLInputElement | null> | undefined;
+  imageData: {
+    data: File | undefined;
+    preview: string;
+  };
+  setImageData: Dispatch<
+    SetStateAction<{
+      data: File | undefined;
+      preview: string;
+    }>
+  >;
+  location?: 'mypage' | 'modal';
+};
+
+/** 파일 인풋입니다.
+ * @props inputRef : 반드시 ref 지정해야함
+ * @props imageData : {data, preview} 형식의 state(ImageInputProps의 타입을 그대로 사용하면 됩니다.)
+ * @props setImageData : setState(ImageInputProps의 타입을 그대로 사용하면 됩니다.)
+ * @props location : 디폴드값 mypage이며, modal은 모달용으로 사이즈가 작습니다.
+ * @alert data 전송방식은 반드시 multipart/form-data를 사용
+ */
+export default function ImageInput({
+  inputRef,
+  imageData,
+  setImageData,
+  location = 'mypage',
+}: ImageInputProps) {
+  const handleChange = (
+    e: SyntheticEvent & {
+      target: HTMLInputElement & { files: FileList | null };
+    },
+  ) => {
+    setImageData((prevValue) => ({ ...prevValue, data: e.target.files?.[0] }));
+  };
+
+  useEffect(() => {
+    if (!imageData.data) return undefined;
+    const nextPreview = URL.createObjectURL(imageData.data);
+    setImageData((prevValue) => ({ ...prevValue, preview: nextPreview }));
+    return () => {
+      URL.revokeObjectURL(nextPreview);
+    };
+  }, [imageData.data]);
+
+  return (
+    <label className={cx('container', location)}>
+      <div className={cx('container', location)}>
+        {imageData.data ? (
+          <Image src={imageData.preview} alt="미리보기" fill />
+        ) : (
+          <PlusIcon className={cx('icon')} />
+        )}
+      </div>
+      <input
+        ref={inputRef}
+        onChange={handleChange}
+        type="file"
+        name="file"
+        className={cx('input')}
+      />
+    </label>
+  );
+}


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
파일 인풋 컴포넌트 입니다.


```tsx
import { useRef, useState } from 'react';
import ImageInput from '@/components/commons/ui-image-input/ImageInput';
import { axiosInstance } from '@/lib/api/axiosInstance';

export default function Home() {
  const inputRef = useRef<HTMLInputElement>(null);
  const [imageData, setImageData] = useState<{
    data: File | undefined;
    preview: string;
  }>({
    data: undefined,
    preview: '',
  });

  const handleClick = async () => {
    axiosInstance
      .post(
        'users/me/image',
        { image: imageData.data },
        {
          headers: { 'Content-Type': 'multipart/form-data' },
        },
      )
      .catch((error) => {
        console.log(error);
      });
  };
  return (
    <div>
      랜딩 페이지임
      <ImageInput
        inputRef={inputRef}
        imageData={imageData}
        setImageData={setImageData}
      />
      <button type="button" onClick={handleClick}>
        dd
      </button>
    </div>
  );
}
```
사용예시.
ref와 state는 반드시 전달 되어야 하며, 타입은 위에 작성한대로 사용하면 됩니다.
데이터를 보낼때는 반드시 form-data여야 하고(application/json이 아니에요!)
데이터를 테스트로 해봤는데 sp-taskify~~~ 형식의 url 주소를 반환하게 되어있으므로, modal에서든 mypage에서든 먼저 form-data 요청을 보낸다음 받아온 url로 할일 생성 또는 내 정보 변경 요청을 보내야 합니다. 무조건입니다.

+ 추가설명
state 하위 data는 파일에 대한 객체를 저장하게 됩니다. type="file"인 input에 change 이벤트가 발생할 때 이벤트객체가 가지는 값입니다.
useEffect를 사용해서 값이 바뀌면 preview를 바꾸게 됩니다.
state 하위 preview는 URL로 생성한 blob 이미지 링크를 저장하게 됩니다. string 타입으로 저장되며, 이는 즉 imgURL과 같으므로 미리보기 기능을 지원하게 되는 겁니다.

## 관련 티켓 및 문서
<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #100 
- Closes #100 

## 스크린샷, 녹화


https://github.com/Team-Taskify/Taskify-Web/assets/56223156/02ccb939-28b5-4e1b-88bc-8456d440ed80



### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?