### PR TITLE
106 칩 넘칩 컴포넌트 구현

### DIFF
--- a/taskify-web/src/components/commons/ui-chip-num/NumChip.module.scss
+++ b/taskify-web/src/components/commons/ui-chip-num/NumChip.module.scss
@@ -1,0 +1,22 @@
+@import '../../../styles/mixin';
+@import '../../../styles/variables';
+
+.NumChip {
+  display: flex;
+  min-width: 2rem;
+  max-width: fit-content;
+  height: 2rem;
+  padding: 0.3rem 0.6rem;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-radius: 0.4rem;
+  background: $gray_eeeeee;
+}
+
+/* 스타일 for the chip text */
+.countNumber {
+  color: $gray_787486;
+  text-align: center;
+  font-size: 1.2rem;
+}

--- a/taskify-web/src/components/commons/ui-chip-num/NumChip.tsx
+++ b/taskify-web/src/components/commons/ui-chip-num/NumChip.tsx
@@ -3,7 +3,7 @@ import styles from './NumChip.module.scss';
 
 const cx = classNames.bind(styles);
 
-type Props = {
+type NumChipProps = {
   countNumber: number;
 };
 export default function NumChip({ countNumber }: Props) {

--- a/taskify-web/src/components/commons/ui-chip-num/NumChip.tsx
+++ b/taskify-web/src/components/commons/ui-chip-num/NumChip.tsx
@@ -1,0 +1,15 @@
+import classNames from 'classnames/bind';
+import styles from './NumChip.module.scss';
+
+const cx = classNames.bind(styles);
+
+type Props = {
+  countNumber: number;
+};
+export default function NumChip({ countNumber }: Props) {
+  return (
+    <div className={cx('NumChip')}>
+      <span className={cx('countNumber')}>{countNumber}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?
기본 컴포넌트인 넘칩입니다.
테이블 개수에 따라서 숫자가 나옵니다.
하지만 구현은 
- [ ] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
최소 width 는 fidma에서 준 크기로 최소로 결정해두었고
반응형으로 숫자가 커질수록 배경크기도 변할수있도록 설정해두었습니다.
나피티 도움받음
import NumChip from '@/components/commons/ui-chip-num/NumChip';

export default function Home() {
  return (
    <div>
      랜딩 페이지임
      <NumChip countNumber={3} />
      <NumChip countNumber={300000000000} />
    </div>
  );
}

## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #106
- Closes #106 

## 스크린샷, 녹화
![스크린샷 2024-02-03 175631](https://github.com/Team-Taskify/Taskify-Web/assets/88885994/06f710a3-b1f6-4956-b515-209f44c27dde)


_변경사항을 테스트하는 방법, 테스트에 사용된 기기 및 브라우저, UI 변경에 대한 관련 이미지 등에 대한 지침을 이곳에 기재해 주세요._

### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?
