### PR TITLE
fix134: 드롭다운 리스트 위치 수정

### DIFF
--- a/taskify-web/src/components/commons/ui-dropdown/Dropdown.module.scss
+++ b/taskify-web/src/components/commons/ui-dropdown/Dropdown.module.scss
@@ -15,6 +15,7 @@
   align-items: center;
   position: absolute;
   right: 2rem;
+  top: 5rem;
   padding: 0.6rem;
   border-radius: 0.6rem;
   border: 0.1rem solid $outline;


### PR DESCRIPTION
## 이 PR은 어떤 유형인가요?

- [x] 리팩터링
- [ ] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
- top 수치만 줘서 수정했어요 
## 관련 티켓 및 문서
<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #134 
- Closes #134 

## 스크린샷, 녹화
![드롭다운수정](https://github.com/Team-Taskify/Taskify-Web/assets/148832721/2f69a547-376f-4ddb-80ca-40a20971d217)



### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?