### PR TITLE
fix:137 초대모달 오류수정

### DIFF
--- a/taskify-web/src/components/dashboard/feat-member-list/MemberList.tsx
+++ b/taskify-web/src/components/dashboard/feat-member-list/MemberList.tsx
@@ -9,7 +9,7 @@ const cx = classNames.bind(styles);
 
 export default function MemberList() {
   const { paginationedMembersData, getPaginationedMembers } = useMembers();
-  const [pagination, setPagination] = useState<number>(3);
+  const [pagination, setPagination] = useState<number>(1);
 
   return (
     <section className={cx('container')}>


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [x] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명

### 페이지네이션 기본값 3이던거 수정
테스트하느라 3으로 했는데 다시 1로 바꿨습니다

### 초대 오류시 인풋에 메세지 표시 및 닫힘 방지
- 존재하지 않는 이메일이거나, 이미 초대된 경우 에러 메세지를 표시합니다.
- 에러를 확인할 수 있게 닫힘 방지를 적용 했습니다.
- 성공시에만 닫히도록 바꿨습니다. 화면상에서는 성공시 바로 초대목록에 추가되기 때문에 딱히 메세지가 없어도 괜찮을 듯 하네요.
### 성공시 또 초대모달 오픈할 때 기존 값이 남아있는 문제 수정
- 성공하면 값을 초기화 해주도록 바꿨습니당

## 관련 티켓 및 문서
<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #137 
- Closes #137 

## 스크린샷, 녹화
- 요청 실패했을때 에러메세지 출력 및 닫힘 방지

https://github.com/Team-Taskify/Taskify-Web/assets/56223156/06161958-28ab-468b-ab2f-ed4a7656ae7c

- 요청 성공시 닫힘

https://github.com/Team-Taskify/Taskify-Web/assets/56223156/603fa8ed-1145-430e-8ac8-985cf00a3e71



### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?