### PR TITLE
fix: 141 서브헤더 fixed 수정

### DIFF
--- a/taskify-web/src/components/commons/ui-dashboard-info-label/DashboardInfoLabel.module.scss
+++ b/taskify-web/src/components/commons/ui-dashboard-info-label/DashboardInfoLabel.module.scss
@@ -20,6 +20,7 @@
   display: flex;
   align-items: center;
   .dashboard-color-chip {
+    flex-shrink: 0;
     @include mobile {
       margin-right: 0;
     }
@@ -55,6 +56,7 @@
   }
 
   .dashboard-owner-icon {
+    flex-shrink: 0;
     @include mobile {
       display: none;
     }

--- a/taskify-web/src/components/commons/ui-profile-Label/ProfileLabel.module.scss
+++ b/taskify-web/src/components/commons/ui-profile-Label/ProfileLabel.module.scss
@@ -11,6 +11,7 @@
 
 .ProfileLabelName {
   &.header {
+    flex-shrink: 0;
     height: 100%;
     @include mobile {
       display: none;

--- a/taskify-web/src/components/commons/ui-sidebar/Sidebar.module.scss
+++ b/taskify-web/src/components/commons/ui-sidebar/Sidebar.module.scss
@@ -43,6 +43,7 @@ $animation_duration: 0.2s;
   left: 0;
   top: 0;
   bottom: 0;
+  z-index: 2;
 
   background-color: $surface_container;
   border-right: 0.1rem solid $outline;

--- a/taskify-web/src/components/commons/ui-sub-header/DashboardUserList.module.scss
+++ b/taskify-web/src/components/commons/ui-sub-header/DashboardUserList.module.scss
@@ -21,74 +21,137 @@
   position: relative;
   display: flex;
   width: 100%;
-}
 
-.memberList div:nth-child(n + 4) {
-  display: none;
-}
-
-.memberList div:nth-child(0) {
-  position: absolute;
-
-  @include mobile {
-    right: 0.6rem;
+  @media screen and (min-width: 375px) and (max-width: 767px) {
+    &:has(> :last-child:nth-child(2)) {
+      & > div:nth-child(2) {
+        display: block;
+        position: relative;
+        right: 1rem;
+      }
+    }
+    &:has(> :last-child:nth-child(3)) {
+      & > div:nth-child(2) {
+        display: block;
+        position: relative;
+        right: 1rem;
+      }
+      & > div:nth-child(3) {
+        display: block;
+        position: relative;
+        right: 2rem;
+      }
+    }
+    &:has(> :last-child:nth-child(4)) {
+      & > div:nth-child(2) {
+        display: block;
+        position: relative;
+        right: 1rem;
+      }
+      & > div:nth-child(3) {
+        display: none;
+      }
+      & > div:nth-child(4) {
+        display: block;
+        position: relative;
+        right: 2rem;
+      }
+    }
+    &:has(> :last-child:nth-child(5)) {
+      & > div:nth-child(2) {
+        display: block;
+        position: relative;
+        right: 1rem;
+      }
+      & > div:nth-child(3) {
+        display: none;
+      }
+      & > div:nth-child(4) {
+        display: none;
+      }
+      & > div:nth-child(5) {
+        display: block;
+        position: relative;
+        right: 2rem;
+      }
+    }
   }
 
-  @include tablet {
-    right: 0.7rem;
+  @media screen and (min-width: 768px) and (max-width: 1199px) {
+    &:has(> :last-child:nth-child(2)) {
+      & > div:nth-child(2) {
+        display: block;
+        position: relative;
+        right: 0.8rem;
+      }
+    }
+    &:has(> :last-child:nth-child(3)) {
+      & > div:nth-child(2) {
+        display: block;
+        position: relative;
+        right: 0.8rem;
+      }
+      & > div:nth-child(3) {
+        display: block;
+        position: relative;
+        right: 1.6rem;
+      }
+    }
+    &:has(> :last-child:nth-child(4)) {
+      & > div:nth-child(2) {
+        display: block;
+        position: relative;
+        right: 0.8rem;
+      }
+      & > div:nth-child(3) {
+        display: none;
+      }
+      & > div:nth-child(4) {
+        display: block;
+        position: relative;
+        right: 1.6rem;
+      }
+    }
+    &:has(> :last-child:nth-child(5)) {
+      & > div:nth-child(2) {
+        display: block;
+        position: relative;
+        right: 0.8rem;
+      }
+      & > div:nth-child(3) {
+        display: none;
+      }
+      & > div:nth-child(4) {
+        display: none;
+      }
+      & > div:nth-child(5) {
+        display: block;
+        position: relative;
+        right: 1.6rem;
+      }
+    }
   }
 
   @include desktop {
-    right: 3.4rem;
-  }
-}
-
-.memberList div:nth-child(1) {
-  position: absolute;
-
-  @include mobile {
-    right: -2rem;
-  }
-
-  @include tablet {
-    right: -2.3rem;
-  }
-
-  @include desktop {
-    right: 0.4rem;
-  }
-}
-
-.memberList div:nth-child(2) {
-  position: absolute;
-  right: -2.6rem;
-
-  @include mobile {
-    display: none;
-  }
-
-  @include tablet {
-    display: none;
-  }
-
-  @include desktop {
-    display: flex;
-  }
-}
-
-.memberList div:nth-child(3) {
-  position: absolute;
-  right: -5.6rem;
-
-  @include mobile {
-    display: none;
-  }
-
-  @include tablet {
-    display: none;
-  }
-
-  @include desktop {
-    display: flex;
+    & > div:nth-child(2) {
+      display: block;
+      position: relative;
+      right: 0.8rem;
+    }
+    & > div:nth-child(3) {
+      display: block;
+      position: relative;
+      right: 1.6rem;
+    }
+    & > div:nth-child(4) {
+      display: block;
+      position: relative;
+      right: 2.4rem;
+    }
+    & > div:nth-child(5) {
+      display: block;
+      position: relative;
+      right: 3.2rem;
+    }
   }
 }

--- a/taskify-web/src/components/commons/ui-sub-header/DashboardUserList.tsx
+++ b/taskify-web/src/components/commons/ui-sub-header/DashboardUserList.tsx
@@ -17,15 +17,17 @@ export default function DashboardUserList() {
     <div className={cx('container')}>
       <div className={cx('memberList')}>
         {membersData &&
-          membersData.data?.members.map((member) => (
-            <UserBadge
-              location="header"
-              key={member.id}
-              color={getRandomColor(member.userId)}
-              text={member.email}
-              profileImageUrl=""
-            />
-          ))}
+          membersData.data?.members.map((member) => {
+            return (
+              <UserBadge
+                location="header"
+                key={member.id}
+                color={getRandomColor(member.userId)}
+                text={member.email}
+                profileImageUrl=""
+              />
+            );
+          })}
         {getRemainNumber(width, membersData.data?.totalCount || 0) > 0 && (
           <UserBadge
             location="header"

--- a/taskify-web/src/components/commons/ui-sub-header/SubHeader.module.scss
+++ b/taskify-web/src/components/commons/ui-sub-header/SubHeader.module.scss
@@ -8,6 +8,10 @@
   box-shadow: 0 0.1rem 0 0 $outline;
   height: 7rem;
 
+  position: fixed;
+  z-index: 1;
+  background-color: $surface_container;
+
   @include mobile {
     padding: 1.3rem 1.2rem 1.3rem 7.9rem;
   }

--- a/taskify-web/src/components/dashboard/feat-sub-header/SubHeader.tsx
+++ b/taskify-web/src/components/dashboard/feat-sub-header/SubHeader.tsx
@@ -38,55 +38,6 @@ export default function SubHeader({
       router.push('/mydashboard');
     }
   };
-
-  // const memberData = {
-  //   members: [
-  //     {
-  //       id: 0,
-  //       userId: 5,
-  //       email: 'ytring@test.com',
-  //       nickname: '1',
-  //       profileImageUrl: 'string',
-  //     },
-  //     {
-  //       id: 1,
-  //       userId: 6,
-  //       email: 'ctring@test.com',
-  //       nickname: '2',
-  //       profileImageUrl: 'string',
-  //     },
-  //     {
-  //       id: 2,
-  //       userId: 7,
-  //       email: 'jtring@test.com',
-  //       nickname: '3',
-  //       profileImageUrl: 'string',
-  //     },
-  //     {
-  //       id: 3,
-  //       userId: 8,
-  //       email: 'ktring@test.com',
-  //       nickname: '4',
-  //       profileImageUrl: 'string',
-  //     },
-  //     {
-  //       id: 4,
-  //       userId: 9,
-  //       email: 'string',
-  //       nickname: '5',
-  //       profileImageUrl: 'string',
-  //     },
-  //     {
-  //       id: 5,
-  //       userId: 10,
-  //       email: 'string',
-  //       nickname: '6',
-  //       profileImageUrl: 'string',
-  //     },
-  //   ],
-
-  //   totalCount: 6,
-  // };
   return (
     <UiSubHeader>
       <SubHeaderName>{dashBoardInfoLabel}</SubHeaderName>

--- a/taskify-web/src/components/page-layout/dashboard-layout/DashBoardLayout.module.scss
+++ b/taskify-web/src/components/page-layout/dashboard-layout/DashBoardLayout.module.scss
@@ -1,5 +1,6 @@
 @import '../../../styles/mixin';
 .main {
+  padding-top: 7rem;
   @include mobile {
     padding-left: 6.7rem;
   }


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [ ] 기능
- [x] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명

또 왔습니다. 이번엔 css만 바꿨네요
### 서브헤더 fixed 설정
서브헤더를 fixed로 하고 메인부분 margin을 줬습니다.
사이드바가 z-index가 1이길래 겹쳐서 사이드바는 상위에 위치하게 2로 바꿨습니다.

### 멤버목록 배치 변경
서브헤더에서 멤버목록이 반응형에서 이상하게 뜨길래 수정했습니다. 순서에 의존해 위치를 고정시켰으니까 개수에 큰 문제는 없을 것 같습니다.

### 서브헤더 유저 정보(닉네임 세로로 뜨는 문제)
flex-shrink 사용해서 이제 안삐뚤어집니다.

## 관련 티켓 및 문서
<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #141 
- Closes #141 

## 스크린샷, 녹화

- fixed 해서 가로 스크롤시 문제 없는 화면

https://github.com/Team-Taskify/Taskify-Web/assets/56223156/af83c8c8-4406-4f93-bcfa-33f96dcf5ba6

- 반응형 유저목록 칩

https://github.com/Team-Taskify/Taskify-Web/assets/56223156/f1b664d9-b101-4369-a9ad-187b28d6b033



### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?