### PR TITLE
Fix149 태그 칩 인풋 중복 태그 수정/ 생성 모달 데이터 초기화

### DIFF
--- a/taskify-web/src/components/commons/feat-create-card-modal/CreateCardModal.tsx
+++ b/taskify-web/src/components/commons/feat-create-card-modal/CreateCardModal.tsx
@@ -124,6 +124,20 @@ export default function CreateCardModal({
     if (isModifyForm) {
       getCardData();
     }
+    if (!isModifyForm) {
+      setMemberListValue({
+        userId: 0,
+        email: '',
+        nickname: '',
+        profileImageUrl: '',
+      });
+      setStateListValue({ id: 0, title: '', teamId: '', dashboardId: 0 });
+      setTitleValue('');
+      setDescriptionValue('');
+      setTagDataValue([]);
+      setDueDateValue('');
+      setImageData({ data: undefined, preview: '' });
+    }
   }, [isModifyForm]);
 
   const RequestCreateCard = async () => {
@@ -204,6 +218,16 @@ export default function CreateCardModal({
       tagDataValue.length > 0 &&
       dueDateValue &&
       imageData.data
+    );
+  };
+
+  const isModifyFormValid = () => {
+    return (
+      memberListValue &&
+      titleValue &&
+      descriptionValue &&
+      tagDataValue.length > 0 &&
+      dueDateValue
     );
   };
 
@@ -299,7 +323,7 @@ export default function CreateCardModal({
             <Button
               onClick={RequestModifyCard}
               size="modalMedium"
-              disabled={!isFormValid()}
+              disabled={!isModifyFormValid()}
             >
               수정
             </Button>

--- a/taskify-web/src/components/commons/ui-tag-input/TagInput.tsx
+++ b/taskify-web/src/components/commons/ui-tag-input/TagInput.tsx
@@ -31,7 +31,13 @@ export default function TagInput({
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && inputValue) {
-      setTagDataValue((prevArray) => [...prevArray, inputValue]);
+      setTagDataValue((prevArray) => {
+        if (!prevArray.includes(inputValue)) {
+          return [...prevArray, inputValue];
+        }
+        alert('중복된 태그명 입니다.');
+        return prevArray;
+      });
       setInputValue('');
       setIsButtonList(true);
     }


### PR DESCRIPTION

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [ ] 기능
- [x] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
- 동일한 태그명 입력 시 중복된 key값으로 인해 오류 발생
  원인 :  태그는 빈 배열을 생성하여 map으로 나열하기때문에 고유한 id값이 없음, 태그의 value값을 key값으로 설정하였기때문에 중복된 value를 입력하면 key값이 중복처리됨
  해결 : 동일한 value값을 포함한 배열을 생성하게되면 이전 배열값으로 리턴하고 alert경고창이 팝업되도록 수정하였습니다.

- 수정모달은 컴포넌트가 렌더링되면 카드에 입력된 데이터를 불러오는데, 이때 입력된 데이터가 생성 모달에서도 적용되는 문제를 발견함
  원인 : isModify값이 아닌 생성모달을 렌더링했을때 입력된값을 초기화를 안함
  해결 : useEffect에서 isModify값이 false일경우 기본 입력값들을 초기화 하도록 수정하였습니다.

- 수정 모달은 이미지를 업로드 하지않아도 기본 저장된 이미지를 그대로 수정요청 가능해야하는데, 버튼 disabled값에 전달하는 함수에 이미지 데이터도 true값을 반환하도록  하고 있어서 수정하였습니다.

## 관련 티켓 및 문서
<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #149 
- Closes #149 

## 스크린샷, 녹화
- 중복된 태그 입력 시 alert창 팝업
![태그 중복문제 수정](https://github.com/Team-Taskify/Taskify-Web/assets/148832721/e996d989-0c1b-419a-92ae-08229773f5e2)


- 생성모달 컴포넌트에서는 수정모달의 기본데이터가 초기화 
![모달수정](https://github.com/Team-Taskify/Taskify-Web/assets/148832721/5a20e09e-e0b8-4714-9f94-ba698d1ea329)



### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?