### PR TITLE
Fix159 서브헤더 관리버튼 push 수정 서브헤더 member list 유저 profile url 전달

### DIFF
--- a/taskify-web/src/components/commons/ui-sub-header/DashboardUserList.tsx
+++ b/taskify-web/src/components/commons/ui-sub-header/DashboardUserList.tsx
@@ -12,7 +12,7 @@ export default function DashboardUserList() {
   const { width } = getWindowSize();
 
   const { membersData } = useMembers();
-
+  console.log(membersData);
   return (
     <div className={cx('container')}>
       <div className={cx('memberList')}>
@@ -24,7 +24,7 @@ export default function DashboardUserList() {
                 key={member.id}
                 color={getRandomColor(member.userId)}
                 text={member.email}
-                profileImageUrl=""
+                profileImageUrl={member.profileImageUrl}
               />
             );
           })}

--- a/taskify-web/src/components/commons/ui-sub-header/DashboardUserList.tsx
+++ b/taskify-web/src/components/commons/ui-sub-header/DashboardUserList.tsx
@@ -10,9 +10,8 @@ const cx = classNames.bind(styles);
 
 export default function DashboardUserList() {
   const { width } = getWindowSize();
-
   const { membersData } = useMembers();
-  console.log(membersData);
+
   return (
     <div className={cx('container')}>
       <div className={cx('memberList')}>

--- a/taskify-web/src/components/commons/ui-sub-header/SubHeaderButton.tsx
+++ b/taskify-web/src/components/commons/ui-sub-header/SubHeaderButton.tsx
@@ -26,7 +26,7 @@ export default function SubHeaderButton({
           type="button"
           onClick={() => {
             if (!router.asPath.includes('edit')) {
-              router.push('./edit');
+              router.push(`${router.asPath}/edit`);
             }
           }}
         >


### PR DESCRIPTION
## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [ ] 기능
- [x] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
- 서브헤더 관리버튼 push 수정
- 서브헤더 맴버리스트 이미지 props 추가

## 관련 티켓 및 문서
<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #159 
- Closes #159 

## 스크린샷, 녹화

![관리버튼](https://github.com/Team-Taskify/Taskify-Web/assets/148832721/de45f2fb-d6d6-471d-88c9-34e3d8e713f4)


### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?