### PR TITLE
hotFix: "카드모달 setState를 prop으로 직접 전달하는 부분 콜백으로 변경"

### DIFF
--- a/taskify-web/src/components/commons/feat-create-card-modal/CreateCardModal.tsx
+++ b/taskify-web/src/components/commons/feat-create-card-modal/CreateCardModal.tsx
@@ -46,7 +46,7 @@ type CreateCardModalProps = {
   columnIdNumber: number;
   cardId?: number;
   isModifyForm?: boolean;
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsOpen: (isOpen: boolean) => void;
 };
 
 export default function CreateCardModal({

--- a/taskify-web/src/components/dashboard/feat-column/DashboardCardColumn.tsx
+++ b/taskify-web/src/components/dashboard/feat-column/DashboardCardColumn.tsx
@@ -79,8 +79,8 @@ export default function DashboardCardColumn({
       <CreateCardModal
         columnIdNumber={column.id}
         isOpen={isCardCreateModalVisible}
-        onClick={() => {
-          setCardCreateModalVisible(false);
+        setIsOpen={(isOpen) => {
+          setCardCreateModalVisible(isOpen);
         }}
       />
     </div>


### PR DESCRIPTION
단방향 UI 흐름에 위배되는 부분 (setState를 직접 하위 컴포넌트로 넘김)을 수정했습니다