### PR TITLE
hotfix:170 hotfix 초기 로그인 시 대시보드목록 뜨지 않는 문제 수정

### DIFF
--- a/taskify-web/src/components/dashboard/feat-sub-header/SubHeader.tsx
+++ b/taskify-web/src/components/dashboard/feat-sub-header/SubHeader.tsx
@@ -23,12 +23,13 @@ export default function SubHeader({
   const { subHeaderButtonList } = TEXT;
   const router = useRouter();
 
-  const { user } = useAuth();
+  const { user, clearUser } = useAuth();
 
   const handleRouteOnClick = async (e: React.MouseEvent) => {
     const input = e.target as HTMLElement;
     if (input.innerText === '로그아웃') {
       sessionStorage.clear();
+      clearUser();
       router.push('/');
     }
     if (input.innerText === '내 정보') {

--- a/taskify-web/src/contexts/AuthProvider.tsx
+++ b/taskify-web/src/contexts/AuthProvider.tsx
@@ -29,6 +29,7 @@ type AuthContextType = {
     password,
     newPassword,
   }: ChangePasswordForm) => Promise<void>;
+  clearUser: () => void;
   error: AxiosError | null;
   success: boolean;
 };
@@ -41,6 +42,7 @@ const AuthContext = createContext<AuthContextType>({
   signup: async () => {},
   updateMe: async () => {},
   changePassword: async () => {},
+  clearUser: () => {},
   error: null,
   success: false,
 });
@@ -188,6 +190,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
     [],
   );
 
+  const clearUser = useCallback(() => {
+    setValue((prevValue) => ({ ...prevValue, isPending: false, user: null }));
+  }, []);
+
   useEffect(() => {
     getMe();
   }, []);
@@ -200,6 +206,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       signup,
       updateMe,
       changePassword,
+      clearUser,
       error: axiosError,
       success: axiosSuccess,
     }),
@@ -210,6 +217,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       signup,
       updateMe,
       changePassword,
+      clearUser,
       axiosError,
       axiosSuccess,
     ],

--- a/taskify-web/src/contexts/DashBoardProvider.tsx
+++ b/taskify-web/src/contexts/DashBoardProvider.tsx
@@ -151,7 +151,7 @@ export function DashBoardProvider({ children }: DashBoardProviderProps) {
         getDashBoard();
       }
     }
-  }, [router.isReady]);
+  }, [router.isReady, router.asPath, boardId]);
 
   const memoizedValue = useMemo(
     () => ({

--- a/taskify-web/src/contexts/MemberProvider.tsx
+++ b/taskify-web/src/contexts/MemberProvider.tsx
@@ -211,7 +211,7 @@ export function MemberProvider({ children }: MemberProviderProps) {
         getMembers();
       }
     }
-  }, [router.isReady]);
+  }, [router.isReady, boardId]);
 
   const memoizedValue = useMemo(
     () => ({


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [x] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
최초 로그인, 그리고 대시보드간 이동시에 대시보드 정보 및 멤버 목록이 새로 반영되지 않는 문제 해결했습니다.

## 관련 티켓 및 문서
<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #170 
- Closes #170 

## 스크린샷, 녹화


https://github.com/Team-Taskify/Taskify-Web/assets/56223156/b2e96a06-500e-4bae-8689-06566647b7c9



### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?