### PR TITLE
Fix173 나의대시보드 대시보드생성 부분 렌더링오류수정

### DIFF
--- a/taskify-web/src/components/dashboard/feat-add-dashboard-modal/AddDashboardModal.tsx
+++ b/taskify-web/src/components/dashboard/feat-add-dashboard-modal/AddDashboardModal.tsx
@@ -12,6 +12,7 @@ import { useDashBoard } from '@/contexts/DashBoardProvider';
 type AddDashboardModalProps = {
   isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
+  getDashboardListData: () => Promise<void>;
 };
 
 const cx = classNames.bind(styles);
@@ -19,6 +20,7 @@ const cx = classNames.bind(styles);
 export default function AddDashboardModal({
   isOpen,
   setIsOpen,
+  getDashboardListData,
 }: AddDashboardModalProps) {
   const [selectedColor, setSelectedColor] = useState<ColorChipColor>('#7AC555');
   const { control, watch } = useForm({
@@ -33,6 +35,7 @@ export default function AddDashboardModal({
       color: selectedColor,
       title: watch('dashboardName'),
     });
+    getDashboardListData();
     setIsOpen(false);
   };
 

--- a/taskify-web/src/components/dashboard/feat-my-dashboard-list/MydashboardList.tsx
+++ b/taskify-web/src/components/dashboard/feat-my-dashboard-list/MydashboardList.tsx
@@ -59,7 +59,11 @@ export default function MydashboadList() {
 
   return (
     <div className={cx('container')}>
-      <AddDashboardModal isOpen={isOpen} setIsOpen={setIsOpen} />
+      <AddDashboardModal
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        getDashboardListData={getDashboardListData}
+      />
       <div className={cx('dashboard-list')}>
         {isPageFirst() && (
           <AddButton


### PR DESCRIPTION
## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [ ] 기능
- [x] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
- 나의 대시보드 생성 시 렌더링이 안되는 문제 수정
해결 방법 : 대시보드 페이지네이션 목록 GET 요청 함수를 AddDashboardModal에 전달하여 대시보드 생성하면 대시보드 목록을 한번 더 불러와서 초기화하는 방법으로 수정하였습니다. (광현님께서 알려주심)

## 관련 티켓 및 문서
<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #173 
- Closes #173 

## 스크린샷, 녹화

![대시보드 목록 클릭_ 대시보드 생성](https://github.com/Team-Taskify/Taskify-Web/assets/148832721/14b2250a-8a01-424a-968b-d20099e916d3)

### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?