### PR TITLE
Feat175 칼럼 추가하기 모달 구현 및 여러 컴포넌트 css와 페이지네이션 수정

### DIFF
--- a/taskify-web/src/components/commons/feat-create-card-modal/CreateCardModal.tsx
+++ b/taskify-web/src/components/commons/feat-create-card-modal/CreateCardModal.tsx
@@ -46,7 +46,7 @@ type CreateCardModalProps = {
   columnIdNumber: number;
   cardId?: number;
   isModifyForm?: boolean;
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsOpen: (isOpen: boolean) => void;
 };
 
 export default function CreateCardModal({

--- a/taskify-web/src/components/commons/feat-create-column-modal/CreateColumnModal.module.scss
+++ b/taskify-web/src/components/commons/feat-create-column-modal/CreateColumnModal.module.scss
@@ -1,0 +1,89 @@
+@import '../../../styles/variables';
+@import '../../../styles/mixin';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  @include mobile {
+    height: 24.1rem;
+    width: 32.7rem;
+  }
+
+  @include tablet {
+    width: 54rem;
+    height: 27.6rem;
+  }
+}
+
+.title {
+  font-weight: $font_weight_bold;
+  @include mobile {
+    font-size: $font_size_xlarge;
+  }
+
+  @include tablet {
+    font-size: $font_size_xxlarge;
+  }
+}
+
+.input-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  @include mobile {
+    font-size: $font_size_xlarge;
+    padding-top: 2.4rem;
+    padding-bottom: 2.4rem;
+  }
+
+  @include tablet {
+    padding-top: 3.2rem;
+    padding-bottom: 2.8rem;
+  }
+}
+
+.input {
+  border-radius: 0.6rem;
+  border: 0.1rem solid $outline;
+  outline: none;
+  width: 100%;
+  padding: 1.3rem 1.6rem;
+  &:focus {
+    border: 0.1rem solid $primary;
+  }
+  @include mobile {
+    height: 4.2rem;
+  }
+
+  @include tablet {
+    height: 4.8rem;
+  }
+}
+
+.input-title {
+  @include mobile {
+    font-size: $font_size_medium;
+  }
+
+  @include tablet {
+    font-size: $font_size_large;
+  }
+}
+
+.input-error {
+  font-size: $font_size_small;
+  color: $red_d6173a;
+}
+
+.button {
+  display: flex;
+  justify-content: flex-end;
+  @include mobile {
+    gap: 1.1rem;
+  }
+
+  @include tablet {
+    gap: 1.2rem;
+  }
+}

--- a/taskify-web/src/components/commons/feat-create-column-modal/CreateColumnModal.tsx
+++ b/taskify-web/src/components/commons/feat-create-column-modal/CreateColumnModal.tsx
@@ -1,0 +1,116 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import classNames from 'classnames/bind';
+import styles from './CreateColumnModal.module.scss';
+import { Modal } from '../ui-modal/Modal';
+import Button from '../ui-button/Button';
+import { axiosInstance } from '@/lib/api/axiosInstance';
+
+const cx = classNames.bind(styles);
+
+type ColumnData = {
+  result: string;
+  data: [
+    {
+      id: number;
+      title: string;
+      teamId: string;
+      dashboardId: number;
+      createdAt: string;
+      updatedAt: string;
+    },
+  ];
+};
+
+type CreateColumnModalProps = {
+  isOpen: boolean;
+  onClick: () => void;
+};
+
+export default function CreateColumnModal({
+  isOpen,
+  onClick,
+}: CreateColumnModalProps) {
+  const [isError, setIsError] = useState<boolean>(false);
+  const [inputValue, setInputValue] = useState<string>('');
+  const [columnData, setColumnData] = useState<ColumnData>();
+  const router = useRouter();
+  const { boardId } = router.query;
+
+  const columnsData = async () => {
+    try {
+      const response = await axiosInstance.get(
+        `columns?dashboardId=${boardId}`,
+      );
+      const newData = response.data;
+      setColumnData(newData);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  useEffect(() => {
+    columnsData();
+  }, []);
+
+  const createColumnRequest = async () => {
+    const isTitleVaild = columnData?.data.find(
+      (columnTitle) => columnTitle.title === inputValue,
+    );
+    if (isTitleVaild) {
+      setIsError(true);
+      return;
+    }
+    if (!isTitleVaild) {
+      try {
+        await axiosInstance.post('columns', {
+          title: inputValue,
+          dashboardId: Number(boardId),
+        });
+      } catch (error) {
+        console.log(error);
+      }
+      setIsError(false);
+      columnsData();
+      onClick();
+    }
+  };
+
+  const handleInputValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+  };
+
+  return (
+    <Modal isOpen={isOpen}>
+      <div className={cx('container')}>
+        <div className={cx('title')}>
+          <span>새 컬럼 생성</span>
+        </div>
+        <div className={cx('input-container')}>
+          <span className={cx('input-title')}>이름</span>
+          <input
+            value={inputValue}
+            onChange={handleInputValue}
+            placeholder="컬럼명을 입력하세요."
+            className={cx('input')}
+          />
+          {isError && (
+            <span className={cx('input-error')}>중복된 컬럼 이름입니다.</span>
+          )}
+        </div>
+        <div className={cx('button')}>
+          <Button theme="secondary" onClick={onClick} size="modalMedium">
+            취소
+          </Button>
+          <Button
+            theme="primary"
+            onClick={createColumnRequest}
+            size="modalMedium"
+          >
+            생성
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/taskify-web/src/components/commons/feat-create-column-modal/CreateColumnModal.tsx
+++ b/taskify-web/src/components/commons/feat-create-column-modal/CreateColumnModal.tsx
@@ -71,7 +71,7 @@ export default function CreateColumnModal({
         console.log(error);
       }
       setIsError(false);
-      columnsData();
+      await columnsData();
       onClick();
     }
   };

--- a/taskify-web/src/components/commons/feat-create-column-modal/CreateColumnModal.tsx
+++ b/taskify-web/src/components/commons/feat-create-column-modal/CreateColumnModal.tsx
@@ -106,6 +106,7 @@ export default function CreateColumnModal({
             theme="primary"
             onClick={createColumnRequest}
             size="modalMedium"
+            disabled={!inputValue}
           >
             생성
           </Button>

--- a/taskify-web/src/components/commons/ui-user-badge/UserBadge.module.scss
+++ b/taskify-web/src/components/commons/ui-user-badge/UserBadge.module.scss
@@ -10,7 +10,7 @@
   border: 0.2rem solid $surface_container;
 
   &.image {
-    background: cover;
+    object-fit: cover;
   }
 
   &.orange {

--- a/taskify-web/src/components/dashboard/feat-column/DashboardCardColumn.tsx
+++ b/taskify-web/src/components/dashboard/feat-column/DashboardCardColumn.tsx
@@ -79,8 +79,8 @@ export default function DashboardCardColumn({
       <CreateCardModal
         columnIdNumber={column.id}
         isOpen={isCardCreateModalVisible}
-        onClick={() => {
-          setCardCreateModalVisible(false);
+        setIsOpen={(isOpen) => {
+          setCardCreateModalVisible(isOpen);
         }}
       />
     </div>

--- a/taskify-web/src/components/dashboard/feat-my-dashboard-list/MydashboardList.module.scss
+++ b/taskify-web/src/components/dashboard/feat-my-dashboard-list/MydashboardList.module.scss
@@ -32,14 +32,10 @@
     gap: 1rem;
   }
   @include desktop {
-    grid-template-columns: repeat(3, 33.2rem);
-    grid-template-rows: repeat(2, 7rem);
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(2, 1fr);
     gap: 1.3rem 1.2rem;
   }
-}
-
-.dashboard-list button:nth-child(n + 7) {
-  display: none;
 }
 
 .pagination-container {

--- a/taskify-web/src/components/dashboard/feat-my-dashboard-list/MydashboardList.tsx
+++ b/taskify-web/src/components/dashboard/feat-my-dashboard-list/MydashboardList.tsx
@@ -19,7 +19,7 @@ export default function MydashboadList() {
   const [page, setPage] = useState<number>(1);
   const totalCount =
     dashboardData && dashboardData.totalCount ? dashboardData.totalCount : 0;
-  const size = 6;
+  const size = 5;
   const offset = page * size;
   const totalPage = Math.ceil(totalCount / size);
 
@@ -61,12 +61,10 @@ export default function MydashboadList() {
     <div className={cx('container')}>
       <AddDashboardModal isOpen={isOpen} setIsOpen={setIsOpen} />
       <div className={cx('dashboard-list')}>
-        {isPageFirst() && (
-          <AddButton
-            onClick={handleCreateDashBoardModal}
-            addCase="addDashBoard"
-          />
-        )}
+        <AddButton
+          onClick={handleCreateDashBoardModal}
+          addCase="addDashBoard"
+        />
         {dashboardData?.dashboards &&
           dashboardData.dashboards.map((list) => (
             <DashboardEnterButton

--- a/taskify-web/src/components/dashboard/feat-my-invited-dashboard-List/MyInvitedDashboardList.module.scss
+++ b/taskify-web/src/components/dashboard/feat-my-invited-dashboard-List/MyInvitedDashboardList.module.scss
@@ -60,7 +60,7 @@
 .board-list-container {
   display: flex;
   flex-direction: column;
-  overflow: scroll;
+  overflow-y: scroll;
 }
 
 .input {

--- a/taskify-web/src/components/dashboard/ui-dashboard-form/DashboardForm.tsx
+++ b/taskify-web/src/components/dashboard/ui-dashboard-form/DashboardForm.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react';
 import classNames from 'classnames/bind';
 import AddButton from '@/components/commons/ui-add-button/AddButton';
 import styles from './DashboardForm.module.scss';
 import { useColumn } from '@/contexts/ColumnProvider';
 import DashboardCardColumn from '../feat-column/DashboardCardColumn';
+import CreateColumnModal from '@/components/commons/feat-create-column-modal/CreateColumnModal';
 
 const cx = classNames.bind(styles);
 
@@ -12,6 +14,13 @@ const cx = classNames.bind(styles);
 function DashboardForm() {
   const { columns } = useColumn();
 
+  const [isColumnCreateModalVisible, setIsColumnCreateModalVisible] =
+    useState<boolean>(false);
+
+  const onClick = () => {
+    setIsColumnCreateModalVisible(false);
+  };
+
   return (
     <section className={cx('dashboard-form')}>
       {columns.map((column) => {
@@ -20,11 +29,15 @@ function DashboardForm() {
       <div className={cx('dashboard-form__add-column')}>
         <AddButton
           onClick={() => {
-            /** TODO: 칼럼 추가 onClick  */
+            setIsColumnCreateModalVisible(true);
           }}
           addCase="addColumn"
         />
       </div>
+      <CreateColumnModal
+        isOpen={isColumnCreateModalVisible}
+        onClick={onClick}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [x] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
- 컬럼 생성 모달 구현
- 무한 스크롤 기능 스콜이 css y축만 나오도록 수정
- 내 대시보드 페이지 상단 대시보드 버튼 PC버전 grid 크기 fr로수정
- 페이지네이션 2페이지에서 6번째 데이터 사라지는현상 => 각 페이지마다 버튼생성을 왼쪽위에 위치하도록 수정( 애초에 이게 피그마 시안이었는데 제가 제대로 확인못한거같아요. )

## 관련 티켓 및 문서
<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #175 
- Closes #175 

## 스크린샷, 녹화

![컬럼생성](https://github.com/Team-Taskify/Taskify-Web/assets/148832721/10f2de7f-8bdf-4bc4-977e-1fc8d8935dbc)


### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?